### PR TITLE
feat(dom): add element screenshot and sequence capture

### DIFF
--- a/src/commands/shared/optionTypes.ts
+++ b/src/commands/shared/optionTypes.ts
@@ -93,6 +93,16 @@ export interface ScreenshotOptions {
   quality?: number;
   /** Capture full page vs viewport only */
   fullPage?: boolean;
+  /** CSS selector for element capture */
+  selector?: string;
+  /** Cached element index (0-based) from previous query */
+  index?: number;
+  /** Continuous capture mode to directory */
+  follow?: boolean;
+  /** Capture interval in ms for follow mode (string from CLI) */
+  interval?: string;
+  /** Max frames for follow mode (string from CLI) */
+  limit?: string;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -302,6 +302,16 @@ export interface DomGetResult {
 }
 
 /**
+ * Element bounding box coordinates.
+ */
+export interface ElementBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
  * Result of a screenshot operation.
  */
 export interface ScreenshotResult {
@@ -316,6 +326,11 @@ export interface ScreenshotResult {
     height: number;
   };
   fullPage: boolean;
+  element?: {
+    selector?: string;
+    index?: number;
+    bounds: ElementBounds;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `--selector` option for CSS selector-based element capture
- Add `--index` option for cached element index from previous query  
- Add `--follow` mode for continuous capture to directory
- Add `--interval` and `--limit` options for sequence control

## New Features

### Element Screenshots
```bash
bdg dom screenshot hero.png --selector ".hero-banner"
bdg dom screenshot button.png --index 3    # From previous query
```

### Screenshot Sequences
```bash
bdg dom screenshot ./frames/ --follow --interval 500 --limit 10
# Creates: 001.png, 002.png, ... every 500ms
```

### Combined (Element + Sequence)
```bash
bdg dom screenshot ./frames/ --selector "header" --follow --interval 1s
```

## Test Plan

- [x] Basic page screenshot still works
- [x] Element screenshot with `--selector` on example.com
- [x] Element screenshot with `--index` from query cache
- [x] Screenshot sequence with `--follow` and `--limit`
- [x] Error handling for invalid selectors (exit 83)
- [x] Error handling for invalid index (exit 81)
- [x] JSON output includes element bounds
- [x] JPEG format with quality settings
- [x] Tested on complex site (github.com)
- [x] Element sequence capture (`--follow` + `--selector`)

Closes #107