### PR TITLE
feat: add shell quote damage detection for better agent error recovery

### DIFF
--- a/src/commands/dom/a11y.ts
+++ b/src/commands/dom/a11y.ts
@@ -48,6 +48,10 @@ import { EXIT_CODES } from '@/utils/exitCodes.js';
  * Dumps the full accessibility tree for the current page via IPC.
  * Filters out ignored nodes for cleaner output.
  *
+ * JSON output returns nodes as an array for natural jq filtering:
+ *   bdg dom a11y tree --json | jq '.data.nodes[] | select(.role == "checkbox")'
+ *   bdg dom a11y tree --json | jq '.data.nodes[0]'
+ *
  * @param options - Command options
  */
 async function handleA11yTree(options: A11yTreeCommandOptions): Promise<void> {
@@ -56,7 +60,7 @@ async function handleA11yTree(options: A11yTreeCommandOptions): Promise<void> {
       const tree = await collectA11yTree();
       return {
         root: tree.root,
-        nodes: Object.fromEntries(tree.nodes),
+        nodes: Array.from(tree.nodes.values()),
         count: tree.count,
       };
     });

--- a/src/commands/dom/evalHelpers.ts
+++ b/src/commands/dom/evalHelpers.ts
@@ -163,7 +163,7 @@ export async function executeScript(
   if (response.exceptionDetails) {
     const errorMsg =
       response.exceptionDetails.exception?.description ?? 'Unknown error executing script';
-    const err = scriptExecutionError(errorMsg);
+    const err = scriptExecutionError(errorMsg, script);
     throw new CommandError(err.message, { suggestion: err.suggestion }, EXIT_CODES.SOFTWARE_ERROR);
   }
 

--- a/src/utils/__tests__/shellDetection.unit.test.ts
+++ b/src/utils/__tests__/shellDetection.unit.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Shell Detection Unit Tests
+ *
+ * Tests shell quote damage detection for selectors and scripts.
+ *
+ * Following testing philosophy:
+ * - Test the BEHAVIOR: "Detects damaged input, provides actionable suggestions"
+ * - Test the PROPERTY: "Never throws, always returns valid result"
+ * - No mocking needed - pure utility functions
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  detectSelectorQuoteDamage,
+  detectScriptQuoteDamage,
+  hasAttributeSelector,
+} from '@/utils/shellDetection.js';
+
+void describe('Shell Detection Utilities', () => {
+  void describe('hasAttributeSelector()', () => {
+    void it('returns true for attribute selectors', () => {
+      assert.equal(hasAttributeSelector('[data-test=value]'), true);
+      assert.equal(hasAttributeSelector('[type=submit]'), true);
+      assert.equal(hasAttributeSelector('input[name=email]'), true);
+    });
+
+    void it('returns false for simple selectors', () => {
+      assert.equal(hasAttributeSelector('#id'), false);
+      assert.equal(hasAttributeSelector('.class'), false);
+      assert.equal(hasAttributeSelector('button'), false);
+      assert.equal(hasAttributeSelector('div.class#id'), false);
+    });
+
+    void it('returns true for quoted attribute selectors', () => {
+      assert.equal(hasAttributeSelector('[data-test="value"]'), true);
+      assert.equal(hasAttributeSelector("[type='submit']"), true);
+    });
+  });
+
+  void describe('detectSelectorQuoteDamage()', () => {
+    void describe('detects damaged selectors', () => {
+      void it('detects unquoted attribute value', () => {
+        const result = detectSelectorQuoteDamage('[data-test=value]');
+
+        assert.equal(result.damaged, true);
+        assert.equal(result.type, 'attribute-selector');
+        assert.ok(result.details?.includes('data-test'));
+        assert.ok(result.details?.includes('value'));
+        assert.ok(result.suggestion?.includes('bdg dom query'));
+      });
+
+      void it('detects unquoted type attribute', () => {
+        const result = detectSelectorQuoteDamage('[type=submit]');
+
+        assert.equal(result.damaged, true);
+        assert.ok(result.details?.includes('type'));
+        assert.ok(result.details?.includes('submit'));
+      });
+
+      void it('detects nested selector with unquoted attribute', () => {
+        const result = detectSelectorQuoteDamage('form [name=email]');
+
+        assert.equal(result.damaged, true);
+        assert.ok(result.details?.includes('name'));
+      });
+    });
+
+    void describe('accepts valid selectors', () => {
+      void it('accepts properly quoted double quotes', () => {
+        const result = detectSelectorQuoteDamage('[data-test="value"]');
+
+        assert.equal(result.damaged, false);
+      });
+
+      void it('accepts properly quoted single quotes', () => {
+        const result = detectSelectorQuoteDamage("[data-test='value']");
+
+        assert.equal(result.damaged, false);
+      });
+
+      void it('accepts simple selectors without attributes', () => {
+        assert.equal(detectSelectorQuoteDamage('#id').damaged, false);
+        assert.equal(detectSelectorQuoteDamage('.class').damaged, false);
+        assert.equal(detectSelectorQuoteDamage('button').damaged, false);
+        assert.equal(detectSelectorQuoteDamage('div > p').damaged, false);
+      });
+
+      void it('accepts empty selector', () => {
+        const result = detectSelectorQuoteDamage('');
+
+        assert.equal(result.damaged, false);
+      });
+    });
+
+    void describe('suggestion quality', () => {
+      void it('provides two-step discovery path', () => {
+        const result = detectSelectorQuoteDamage('[data-test=value]');
+
+        assert.ok(result.suggestion?.includes('bdg dom query'));
+        assert.ok(result.suggestion?.includes('bdg dom a11y describe 0'));
+      });
+
+      void it('includes original selector in suggestion', () => {
+        const selector = '[custom-attr=myvalue]';
+        const result = detectSelectorQuoteDamage(selector);
+
+        assert.ok(result.suggestion?.includes(selector));
+      });
+    });
+  });
+
+  void describe('detectScriptQuoteDamage()', () => {
+    void describe('detects bare function arguments', () => {
+      void it('detects querySelector with bare argument', () => {
+        const result = detectScriptQuoteDamage('document.querySelector(input)');
+
+        assert.equal(result.damaged, true);
+        assert.equal(result.type, 'unquoted-argument');
+        assert.ok(result.details?.includes('querySelector'));
+        assert.ok(result.details?.includes('input'));
+      });
+
+      void it('detects getElementById with bare argument', () => {
+        const result = detectScriptQuoteDamage('document.getElementById(myId)');
+
+        assert.equal(result.damaged, true);
+        assert.ok(result.details?.includes('getElementById'));
+        assert.ok(result.details?.includes('myId'));
+      });
+
+      void it('detects closest with bare argument', () => {
+        const result = detectScriptQuoteDamage('element.closest(div)');
+
+        assert.equal(result.damaged, true);
+        assert.ok(result.details?.includes('closest'));
+        assert.ok(result.details?.includes('div'));
+      });
+
+      void it('detects getAttribute with bare argument', () => {
+        const result = detectScriptQuoteDamage('el.getAttribute(href)');
+
+        assert.equal(result.damaged, true);
+        assert.ok(result.details?.includes('getAttribute'));
+        assert.ok(result.details?.includes('href'));
+      });
+
+      void it('detects classList.add with bare argument', () => {
+        const result = detectScriptQuoteDamage('el.classList.add(active)');
+
+        assert.equal(result.damaged, true);
+        assert.ok(result.details?.includes('add'));
+        assert.ok(result.details?.includes('active'));
+      });
+
+      void it('detects matches with bare argument', () => {
+        const result = detectScriptQuoteDamage('element.matches(button)');
+
+        assert.equal(result.damaged, true);
+        assert.ok(result.details?.includes('matches'));
+      });
+    });
+
+    void describe('accepts valid scripts', () => {
+      void it('accepts properly quoted strings', () => {
+        assert.equal(detectScriptQuoteDamage('document.querySelector("input")').damaged, false);
+        assert.equal(detectScriptQuoteDamage("document.querySelector('input')").damaged, false);
+        assert.equal(detectScriptQuoteDamage('el.getAttribute("href")').damaged, false);
+      });
+
+      void it('accepts scripts without function calls', () => {
+        assert.equal(detectScriptQuoteDamage('document.title').damaged, false);
+        assert.equal(detectScriptQuoteDamage('window.location.href').damaged, false);
+        assert.equal(detectScriptQuoteDamage('1 + 2').damaged, false);
+      });
+
+      void it('accepts numeric arguments', () => {
+        assert.equal(detectScriptQuoteDamage('array.slice(0, 5)').damaged, false);
+        assert.equal(detectScriptQuoteDamage('Math.max(1, 2, 3)').damaged, false);
+      });
+
+      void it('accepts empty script', () => {
+        const result = detectScriptQuoteDamage('');
+
+        assert.equal(result.damaged, false);
+      });
+    });
+
+    void describe('suggestion quality', () => {
+      void it('provides corrected full expression', () => {
+        const result = detectScriptQuoteDamage('document.querySelector(input).value');
+
+        assert.ok(result.suggestion?.includes('document.querySelector("input").value'));
+      });
+
+      void it('preserves context around damaged part', () => {
+        const result = detectScriptQuoteDamage('element.closest(div).textContent');
+
+        assert.ok(result.suggestion?.includes('element.closest("div").textContent'));
+      });
+
+      void it('includes bdg dom eval command', () => {
+        const result = detectScriptQuoteDamage('func(arg)');
+
+        assert.ok(result.suggestion?.includes('bdg dom eval'));
+      });
+    });
+
+    void describe('unexpected identifier fallback', () => {
+      void it('detects unexpected identifier error pattern', () => {
+        const result = detectScriptQuoteDamage("Unexpected identifier 'foo'");
+
+        assert.equal(result.damaged, true);
+        assert.ok(result.suggestion?.includes('single quotes'));
+      });
+    });
+  });
+
+  void describe('Type safety and edge cases', () => {
+    void it('never throws for any string input', () => {
+      const edgeCases = [
+        '',
+        ' ',
+        '[]',
+        '()',
+        '[=]',
+        'func()',
+        '[[nested]]',
+        'a'.repeat(1000),
+        '🚀',
+        '\n\t',
+        'null',
+        'undefined',
+      ];
+
+      for (const input of edgeCases) {
+        assert.doesNotThrow(
+          () => {
+            detectSelectorQuoteDamage(input);
+            detectScriptQuoteDamage(input);
+            hasAttributeSelector(input);
+          },
+          `Should not throw for input: ${JSON.stringify(input)}`
+        );
+      }
+    });
+
+    void it('always returns valid ShellDamageResult structure', () => {
+      const inputs = ['[test=value]', '#simple', 'func(arg)', 'valid()'];
+
+      for (const input of inputs) {
+        const selectorResult = detectSelectorQuoteDamage(input);
+        const scriptResult = detectScriptQuoteDamage(input);
+
+        assert.equal(typeof selectorResult.damaged, 'boolean');
+        assert.equal(typeof scriptResult.damaged, 'boolean');
+
+        if (selectorResult.damaged) {
+          assert.equal(typeof selectorResult.details, 'string');
+          assert.equal(typeof selectorResult.suggestion, 'string');
+        }
+
+        if (scriptResult.damaged) {
+          assert.equal(typeof scriptResult.details, 'string');
+          assert.equal(typeof scriptResult.suggestion, 'string');
+        }
+      }
+    });
+
+    void it('handles special regex characters safely', () => {
+      const specialChars = ['[test.value]', '[test*=value]', '[test^=value]', 'func(a|b)'];
+
+      for (const input of specialChars) {
+        assert.doesNotThrow(() => {
+          detectSelectorQuoteDamage(input);
+          detectScriptQuoteDamage(input);
+        });
+      }
+    });
+  });
+});

--- a/src/utils/shellDetection.ts
+++ b/src/utils/shellDetection.ts
@@ -1,0 +1,116 @@
+/**
+ * Shell quote damage detection utilities.
+ *
+ * Detects when shell quote handling has corrupted selectors or scripts,
+ * providing actionable suggestions for recovery.
+ */
+
+export interface ShellDamageResult {
+  damaged: boolean;
+  type?: 'attribute-selector' | 'unquoted-argument';
+  details?: string;
+  suggestion?: string;
+}
+
+const ATTRIBUTE_SELECTOR_PATTERN = /\[[\w-]+=/.source;
+const QUOTED_ATTRIBUTE_PATTERN = /\[[\w-]+=['"][^'"]*['"]\]/;
+const UNQUOTED_ATTRIBUTE_PATTERN = /\[([\w-]+)=([\w-]+)\]/;
+const BARE_ARGUMENT_PATTERN = /(\w+)\(\s*([a-zA-Z][\w-]*)\s*\)/;
+const UNEXPECTED_IDENTIFIER_PATTERN = /Unexpected identifier ['"]?(\w+)['"]?/;
+
+function noDamage(): ShellDamageResult {
+  return { damaged: false };
+}
+
+function buildSelectorSuggestion(selector: string): string {
+  return `Use the two-step pattern:\n  1. bdg dom query '${selector}'\n  2. bdg dom a11y describe 0`;
+}
+
+function checkUnquotedAttribute(selector: string): ShellDamageResult {
+  if (QUOTED_ATTRIBUTE_PATTERN.test(selector)) {
+    return noDamage();
+  }
+
+  const match = UNQUOTED_ATTRIBUTE_PATTERN.exec(selector);
+  if (!match) {
+    return noDamage();
+  }
+
+  const [, attr, value] = match;
+  return {
+    damaged: true,
+    type: 'attribute-selector',
+    details: `Received [${attr}=${value}] - quotes appear stripped`,
+    suggestion: buildSelectorSuggestion(selector),
+  };
+}
+
+function checkBareArgument(script: string): ShellDamageResult {
+  const match = BARE_ARGUMENT_PATTERN.exec(script);
+  if (!match) {
+    return noDamage();
+  }
+
+  const [matchedPart, funcName, bareArg] = match;
+  const fixedPart = `${funcName}("${bareArg}")`;
+  const fixedScript = script.replace(matchedPart, fixedPart);
+
+  return {
+    damaged: true,
+    type: 'unquoted-argument',
+    details: `${funcName}(${bareArg}) - quotes stripped by shell`,
+    suggestion: `Try: bdg dom eval '${fixedScript}'`,
+  };
+}
+
+function checkUnexpectedIdentifier(script: string): ShellDamageResult {
+  if (!UNEXPECTED_IDENTIFIER_PATTERN.test(script)) {
+    return noDamage();
+  }
+
+  return {
+    damaged: true,
+    type: 'unquoted-argument',
+    details: 'Unexpected identifier suggests quotes were stripped',
+    suggestion: "Use single quotes around the script: bdg dom eval '...'",
+  };
+}
+
+/**
+ * Checks if a selector contains attribute syntax.
+ *
+ * @param selector - CSS selector to check
+ * @returns True if selector contains attribute syntax
+ */
+export function hasAttributeSelector(selector: string): boolean {
+  return new RegExp(ATTRIBUTE_SELECTOR_PATTERN).test(selector);
+}
+
+/**
+ * Detects shell quote damage in CSS selectors.
+ *
+ * @param selector - The selector as received by the command
+ * @returns Detection result with details and suggestions
+ */
+export function detectSelectorQuoteDamage(selector: string): ShellDamageResult {
+  if (!hasAttributeSelector(selector)) {
+    return noDamage();
+  }
+
+  return checkUnquotedAttribute(selector);
+}
+
+/**
+ * Detects shell quote damage in JavaScript expressions.
+ *
+ * @param script - The script as received by the command
+ * @returns Detection result with details and suggestions
+ */
+export function detectScriptQuoteDamage(script: string): ShellDamageResult {
+  const bareArgResult = checkBareArgument(script);
+  if (bareArgResult.damaged) {
+    return bareArgResult;
+  }
+
+  return checkUnexpectedIdentifier(script);
+}


### PR DESCRIPTION
## Summary
- Add shell quote damage detection for attribute selectors (`[data-test=value]`) with discovery path suggestions
- Add script quote damage detection for expressions like `querySelector(input)` with corrected suggestions
- Add CDP domain/method notes for event-based domains (Audits, Overlay, Profiler, etc.) explaining async result patterns
- New `shellDetection.ts` utility with comprehensive pattern matching and unit tests

## Test plan
- [x] Test attribute selector quote detection: `bdg dom a11y describe '[data-test=value]'`
- [x] Test script quote detection: `bdg dom eval 'document.querySelector(input).value'`
- [x] Test CDP event-based hints: `bdg cdp Audits.checkContrast` and `bdg cdp Audits --describe`
- [x] Test a11y tree JSON output: `bdg dom a11y tree --json | jq '.nodes[0]'`
- [x] Unit tests pass for shellDetection utility

Closes #126