### PR TITLE
fix: respect --user-data-dir from BDG_CHROME_FLAGS and --chrome-flags

### DIFF
--- a/src/commands/__tests__/userDataDir.unit.test.ts
+++ b/src/commands/__tests__/userDataDir.unit.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for `--user-data-dir` extraction from merged chrome flags.
+ *
+ * Regression coverage for issue #160: `--user-data-dir` supplied via
+ * `BDG_CHROME_FLAGS` or `--chrome-flags` must be promoted to the canonical
+ * `userDataDir` field and stripped from the flag list, so Chrome never
+ * receives duplicate `--user-data-dir` switches.
+ */
+
+import * as assert from 'node:assert';
+import * as os from 'node:os';
+import { describe, test } from 'node:test';
+
+import { expandHome, extractUserDataDirFromFlags } from '@/commands/start.js';
+
+describe('extractUserDataDirFromFlags', () => {
+  test('returns undefined path and untouched flags when no user-data-dir present', () => {
+    const result = extractUserDataDirFromFlags(['--ignore-certificate-errors', '--flag=value']);
+    assert.strictEqual(result.userDataDir, undefined);
+    assert.deepStrictEqual(result.rest, ['--ignore-certificate-errors', '--flag=value']);
+  });
+
+  test('extracts --user-data-dir=<path> form', () => {
+    const result = extractUserDataDirFromFlags(['--user-data-dir=/tmp/profile', '--other']);
+    assert.strictEqual(result.userDataDir, '/tmp/profile');
+    assert.deepStrictEqual(result.rest, ['--other']);
+  });
+
+  test('extracts --user-data-dir <path> space-separated form', () => {
+    const result = extractUserDataDirFromFlags(['--user-data-dir', '/tmp/profile', '--other']);
+    assert.strictEqual(result.userDataDir, '/tmp/profile');
+    assert.deepStrictEqual(result.rest, ['--other']);
+  });
+
+  test('expands leading ~/ in extracted path', () => {
+    const result = extractUserDataDirFromFlags(['--user-data-dir=~/my-profile']);
+    assert.strictEqual(result.userDataDir, `${os.homedir()}/my-profile`);
+    assert.deepStrictEqual(result.rest, []);
+  });
+
+  test('last occurrence wins when flag is specified multiple times', () => {
+    const result = extractUserDataDirFromFlags([
+      '--user-data-dir=/first',
+      '--other',
+      '--user-data-dir=/second',
+    ]);
+    assert.strictEqual(result.userDataDir, '/second');
+    assert.deepStrictEqual(result.rest, ['--other']);
+  });
+
+  test('preserves flag order for non-matching entries', () => {
+    const result = extractUserDataDirFromFlags(['--a', '--user-data-dir=/p', '--b', '--c=1']);
+    assert.deepStrictEqual(result.rest, ['--a', '--b', '--c=1']);
+  });
+
+  test('leaves --user-data-dir as final token unmatched (no path follows)', () => {
+    const result = extractUserDataDirFromFlags(['--other', '--user-data-dir']);
+    assert.strictEqual(result.userDataDir, undefined);
+    assert.deepStrictEqual(result.rest, ['--other', '--user-data-dir']);
+  });
+});
+
+describe('expandHome', () => {
+  test('expands leading ~/', () => {
+    assert.strictEqual(expandHome('~/foo'), `${os.homedir()}/foo`);
+  });
+
+  test('leaves absolute paths unchanged', () => {
+    assert.strictEqual(expandHome('/abs/path'), '/abs/path');
+  });
+
+  test('leaves relative paths unchanged', () => {
+    assert.strictEqual(expandHome('relative/path'), 'relative/path');
+  });
+
+  test('does not expand ~ without trailing slash', () => {
+    assert.strictEqual(expandHome('~user'), '~user');
+  });
+});

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -47,6 +47,49 @@ function hasDisplay(): boolean {
 }
 
 /**
+ * Expand a leading `~/` in a path to the user's home directory.
+ * Chrome itself does not expand `~`, so bdg normalizes it for users.
+ */
+export function expandHome(value: string): string {
+  return value.startsWith('~/') ? value.replace(/^~/, os.homedir()) : value;
+}
+
+/**
+ * Extract `--user-data-dir` from a flags array.
+ *
+ * Supports both `--user-data-dir=<path>` and `--user-data-dir <path>` forms.
+ * When found, returns the path (with `~/` expanded) and the remaining flags
+ * with every matching entry removed, so callers can avoid passing the same
+ * switch to Chrome twice.
+ */
+export function extractUserDataDirFromFlags(flags: string[]): {
+  userDataDir: string | undefined;
+  rest: string[];
+} {
+  const rest: string[] = [];
+  let userDataDir: string | undefined;
+
+  for (let i = 0; i < flags.length; i++) {
+    const flag = flags[i] as string;
+    if (flag.startsWith('--user-data-dir=')) {
+      userDataDir = flag.slice('--user-data-dir='.length);
+      continue;
+    }
+    if (flag === '--user-data-dir' && i + 1 < flags.length) {
+      userDataDir = flags[i + 1];
+      i++;
+      continue;
+    }
+    rest.push(flag);
+  }
+
+  return {
+    userDataDir: userDataDir ? expandHome(userDataDir) : undefined,
+    rest,
+  };
+}
+
+/**
  * Apply shared telemetry options to a command
  *
  * @param command - Commander.js Command instance to apply options to
@@ -105,15 +148,17 @@ function buildSessionOptions(options: CollectorOptions): {
     : undefined;
   const timeout = options.timeout ? timeoutRule.validate(options.timeout) : undefined;
 
-  let userDataDir = options.userDataDir;
-  if (userDataDir?.startsWith('~/')) {
-    userDataDir = userDataDir.replace(/^~/, os.homedir());
-  }
-
   // Merge env var flags with CLI flags (CLI flags come after, taking precedence)
   const envFlags = process.env['BDG_CHROME_FLAGS']?.split(' ').filter(Boolean) ?? [];
   const cliFlags = options.chromeFlags?.split(' ').filter(Boolean) ?? [];
-  const combinedFlags = [...envFlags, ...cliFlags];
+  const { userDataDir: flagUserDataDir, rest: combinedFlags } = extractUserDataDirFromFlags([
+    ...envFlags,
+    ...cliFlags,
+  ]);
+
+  // Precedence: -u / --user-data-dir > --chrome-flags / BDG_CHROME_FLAGS > default
+  const userDataDir = options.userDataDir ? expandHome(options.userDataDir) : flagUserDataDir;
+
   const chromeFlags = combinedFlags.length > 0 ? combinedFlags : undefined;
 
   return {


### PR DESCRIPTION
Closes #160

## Summary
- `--user-data-dir` passed via `BDG_CHROME_FLAGS` or `--chrome-flags` was silently ignored because bdg always passed its own default user-data-dir to chrome-launcher. Chrome received duplicate `--user-data-dir` switches with unreliable precedence, and the default `~/.bdg/chrome-profile` directory was created even when the user supplied an override.
- Extract `--user-data-dir` from the merged flag list in `buildSessionOptions` and promote it to the canonical `userDataDir` field, stripped from the flag list so Chrome gets exactly one `--user-data-dir`.
- Precedence: `-u` > `--chrome-flags` / `BDG_CHROME_FLAGS` > default.

## Test plan
- [x] New unit tests in `src/commands/__tests__/userDataDir.unit.test.ts` cover both `--flag=value` and `--flag value` forms, `~/` expansion, last-occurrence wins, and the trailing-token edge case.
- [x] Full test suite: `npm test` → 630 pass, 0 fail.
- [x] `npm run build` clean, `npm run lint` clean (pre-existing warnings only).
- [x] Manual end-to-end verification (Chrome headless, about:blank):
  - `BDG_CHROME_FLAGS="--user-data-dir=/tmp/X"` populates `/tmp/X`, leaves `~/.bdg/chrome-profile` uncreated.
  - `--chrome-flags="--user-data-dir=/tmp/X"` populates `/tmp/X`, leaves default uncreated.
  - `-u /tmp/A --chrome-flags="--user-data-dir=/tmp/B"` populates `/tmp/A` (precedence honored).
  - No flags → `~/.bdg/chrome-profile` used as before (default preserved).