### PR TITLE
Track: manual testing findings from 0.7.2 (2026-04-16)

### DIFF
--- a/docs/quality/MANUAL_TESTING_2026-04-16.md
+++ b/docs/quality/MANUAL_TESTING_2026-04-16.md
@@ -1,0 +1,254 @@
+# BDG Manual Testing Report
+
+**Version:** 0.7.2
+**Date:** 2026-04-16
+**Platform:** macOS (Darwin 24.6.0)
+
+## Test Methodology
+
+All commands tested in isolated daily-task scenarios using:
+- `example.com` (minimal static page)
+- `httpbin.org/forms/post` (form interactions)
+- `developer.mozilla.org` (complex SPA with analytics/telemetry)
+- Various invalid inputs for error-handling coverage
+
+Artifacts: `/tmp/bdg-test-report/` (screenshots, HARs)
+
+---
+
+## Commands Exercised
+
+| Command | Sub-commands / Flags tested |
+|---|---|
+| `bdg <url>` | Start session; `--all`, `--quiet`, invalid URLs |
+| `bdg status` | Default, `--json`, `--verbose` |
+| `bdg stop` | Default, `--json`, `--kill-chrome` (implicit), no-session |
+| `bdg cleanup` | Default, `--json` |
+| `bdg peek` | `--json`, `--verbose`, `--network`, `--console`, `--dom`, `--last`, `--follow` |
+| `bdg tail` | Default, `--help` |
+| `bdg details` | `network <id>`, `console <idx>`, invalid type, out-of-range |
+| `bdg dom query` | Selectors, `*`, invalid selectors, empty string |
+| `bdg dom get` | Selector, index, `--raw`, `--json` |
+| `bdg dom eval` | Simple, object, promise, throw, syntax error |
+| `bdg dom a11y` | `tree`, `query role:*`, `describe` |
+| `bdg dom form` | Default, `--brief`, `--all`, `--json` |
+| `bdg dom screenshot` | Full page, `--selector` |
+| `bdg dom fill` | Index, selector, invalid selector |
+| `bdg dom click` | Index, selector, radio (by index) |
+| `bdg dom submit` | Form submission |
+| `bdg dom pressKey` | Tab key |
+| `bdg dom scroll` | `--bottom`, `--top`, `--down`, selector |
+| `bdg network list` | `--filter`, `--preset`, `--type`, `--last`, `--json` |
+| `bdg network har` | Export |
+| `bdg network getCookies` | Default, `--json` |
+| `bdg network headers` | Valid ID, invalid ID, missing ID |
+| `bdg network document` | Default |
+| `bdg console` | Default, `--list`, `--level`, `--json` |
+| `bdg cdp` | `--list`, `--search`, `--describe`, execution (valid/invalid) |
+
+---
+
+## 🔴 Critical Bugs
+
+### 1. Form index click hits wrong element (multi-match selectors)
+Clicking a radio/checkbox by form index targets the first element matching its `name` attribute, not the actual indexed element.
+
+**Repro:**
+```bash
+bdg httpbin.org/forms/post
+bdg dom click 4     # Form index 4 is radio "Medium"
+bdg dom form        # Shows [3] Small = checked, not [4] Medium
+```
+
+The click output reports `Selector: input[name="size"]` — the resolver used only the `name` attribute, which matches all three size radios. Happens for all grouped inputs (radios + same-name checkboxes).
+
+**Workaround:** use a CSS selector with `[value=...]`.
+
+**Impact:** Major — breaks the primary "click by index" UX advertised by `bdg dom form`.
+
+### 2. `bdg network list` silently caps at 10 requests
+Regardless of `--last` value (tested 5, 50, 100, 500) or `--all`, the response is hard-capped at 10 entries even though session captured 80+ and HAR exports all 80.
+
+```bash
+bdg status --json | jq .data.activity.networkRequestsCaptured   # 80
+bdg network list --last 500 --json | jq '.data.requests | length'  # 10
+bdg network har x.har                                           # "Exported 80 requests"
+```
+
+**Impact:** Major — analysts using `network list` for auditing get a silently truncated view. The `(last 5 of 10)` header is also misleading (total is actually 80).
+
+### 3. `bdg <unknown-command>` silently attempts to start a session
+Typos at the top level are interpreted as URLs:
+```bash
+bdg unknown
+# → tries to start a new Chrome session targeting "unknown"
+# → only the pre-existing-session guard prevented a new browser launch
+```
+Dangerous for users and agents; there's no "unknown command" hint.
+
+### 4. Stale URL in `bdg status` after in-page navigation
+After JS-navigating to a new page within the same session, `bdg status --json` still returns the old `pageState.url` and `title`. CDP `Runtime.evaluate location.href` confirms the page actually changed.
+```bash
+# navigate from /JavaScript to /Array
+bdg status --json | jq .data.pageState.url   # still .../JavaScript
+bdg cdp Runtime.evaluate --params '{"expression":"location.href"}'  # .../Array
+```
+**Impact:** Agents relying on status to verify navigation get wrong answers.
+
+### 5. `bdg network document` returns favicon, not the main document
+On `httpbin.org/post`, `network document` returned the `favicon.ico` 404 request, not the HTML document. Probably iterates in wrong order or uses the last request matching a loose type filter.
+
+### 6. `bdg network headers` with **no argument** returns random request
+No error; it just prints some request (in my test, `favicon.ico`). Required argument is not enforced.
+
+### 7. Form submit reports `Navigation: no` when navigation did occur
+`bdg dom submit 12` on httpbin form POSTed and navigated to `/post`, but output said `Navigation: no`. Only 1 network request was counted for the submission.
+
+---
+
+## 🟡 Significant Issues
+
+### 8. Exit-code inconsistencies
+- `bdg unknown-flag` → exit **1** (should be **81** INVALID_ARGUMENTS).
+- `bdg details` (missing required arg) → exit **1**.
+- `bdg cdp Runtime.evaluate` (missing params) → exit **104** (CDP error), should be **81**.
+- `bdg "not a url!"` prints error but exits **0**.
+- `bdg <url>` while a session exists prints "Error:" but exits **0** (should be non-zero, e.g., 84).
+
+### 9. `--json` flag doesn't silence human-oriented stderr
+`bdg status --json` with no session prints `Error: No active session found\nStart a session first...` to stderr in addition to JSON. For an automation-first flag this should be pure machine output.
+
+### 10. `status --json` says `success: true` while stderr says "Error:"
+`bdg status --json` without a session returns `{"success": true, "active": false}` but stderr emits `Error: No active session found`. The JSON envelope contradicts the human-readable error.
+
+### 11. Suggestions reference commands that don't exist
+- `bdg status` footer suggests **`bdg query <script>`** — no such top-level command; it's `bdg dom eval`.
+- `bdg status` (empty state) suggests **`bdg tabs`** — no such subcommand exists.
+- Several "Next steps" from `dom query` suggest `bdg details dom 0`; the actual command is `bdg dom get 0`.
+
+### 12. `bdg dom a11y` (bare) prints help instead of dumping the tree
+The help text says the `search` argument is optional and even describes what bare-mode does, yet running with no argument just prints the help. Either the default behavior should match the description or the arg should be required.
+
+### 13. `bdg dom a11y "Example"` fails on partial-name search that should match
+Searched "Example" on example.com where a heading is "Example Domain". Reply:
+```
+Error: No nodes found matching pattern
+Pattern: name:*Example*.
+```
+The wildcard expansion is correct, the node exists — suggests the matcher isn't checking subrole/child text. `bdg dom a11y query "name:Example Domain"` likely would work, but the shorthand doesn't.
+
+### 14. `bdg status` / `bdg stop` start a daemon just to report "no session"
+Running those commands on a clean system spins up and immediately tears down a daemon process. Wasteful and slow.
+
+### 15. `bdg peek --console` (no console msgs) prints only the header + "Tip" — no "(none)" marker
+Compare with `--dom` which prints `DOM: (none)`. Inconsistent feedback.
+
+### 16. `bdg peek --dom` still prints the Network section
+Filter flags don't actually filter — they add sections rather than restrict output.
+
+### 17. `--quiet` only affects session start, not other commands
+`bdg --quiet status` still emits the full tabular output.
+
+### 18. `bdg dom form --brief` doesn't show filled values or checked state
+`--brief` strips the "Value" column entirely, so you can't quickly verify fill/click operations. Defeats the point of a quick-state summary.
+
+### 19. Double colons in `network headers` output
+```
+access-control-allow-credentials::true
+Referer::                  https://httpbin.org/forms/post
+```
+Formatting bug — single colon expected.
+
+### 20. `console %c` directives rendered as raw text
+MDN's `%cairgap.js%c Report-only mode enabled font-size:larger;...` — CSS format args are concatenated into the message text rather than stripped or applied. Poor readability.
+
+### 21. Console `--level info` still shows summary "No errors or warnings"
+When filtering to one level, the summary should either adapt or be suppressed. Currently it always prints the error/warning summary.
+
+### 22. Invalid/empty CSS selectors return exit 0
+`bdg dom query ""` and `bdg dom query "###"` both print "No nodes found" with exit 0. For empty strings especially, this should be a usage error (exit 81).
+
+---
+
+## 🟠 Minor Issues
+
+### 23. Race in parallel DOM queries
+Three parallel `bdg dom query` / `bdg network list` calls on example.com produced one "No nodes found matching 'h1'" even though h1 exists. Reproduced once, not consistently. Likely a query cache or target-selection race.
+
+### 24. Peek deprecation notice is shown but command still works
+`bdg peek --network` prints `Note: "bdg peek --network" is deprecated. Use "bdg network list"...` then happily executes. Fine, but the deprecation has been around long enough to consider a hard error if it's been deprecated more than one release.
+
+### 25. `bdg dom eval` uses quoted JSON strings for simple results
+`bdg dom eval "document.title"` → `"Example Domain"` (with quotes). Agents parsing have to strip quotes vs. non-string returns. Consider `--raw` to match `dom get --raw`.
+
+### 26. Help-output noise on successful start
+Session-start output is 50+ lines of helper text, which dominates CLI logs. Could be collapsed behind `--verbose` / `--help-after-start`.
+
+### 27. Confusing error message for stale DOM cache
+```
+Re-run "bdg dom query cached query" to refresh the cache
+```
+"cached query" reads as a literal argument name; should be `bdg dom query <your-selector>`.
+
+### 28. `bdg network list --filter method:POST` shows "last 1 of 4" but "last 0 of 10" when empty
+When a filter matches nothing, it prints `last 0 of N` which is confusing. Just say "no matching requests".
+
+### 29. The `bdg --help` top-level line suggests using URL as the default command — but combining a command plus a URL conflicts silently
+E.g. `bdg https://example.com status` is accepted as URL only; `status` is ignored. No error.
+
+---
+
+## ✅ What Works Well
+
+- **Core session lifecycle** (start/status/stop/cleanup) — reliable.
+- **CDP discovery**: `--list`, `--search`, `--describe` are excellent.
+- **CDP execution** with case-insensitive method names and helpful hints ("Consider using `bdg network getCookies` instead of...").
+- **Form discovery** (`bdg dom form`) — rich, human-readable, exactly what agents need.
+- **A11y tree / a11y query** — works well for `role:*` patterns.
+- **HAR export** — captures all 80+ requests faithfully.
+- **Screenshot** — full page, element selector, file write all worked on first try.
+- **DOM eval** — clean handling of promises (auto-await), errors with stack traces.
+- **Detailed error suggestions** in JSON envelope (`exitCode`, `suggestion`) — great for agents.
+- **`bdg dom form --brief` index table** pairs well with `dom fill N "value"` for text inputs.
+- **Typo detection**: `Runtime.invalidMethod` → "Did you mean Runtime.evaluate?" — very nice.
+
+---
+
+## Daily-Task Scenarios — Actual Output Summary
+
+| Task | Command Used | Worked? |
+|---|---|---|
+| Read page title | `bdg dom eval "document.title"` | ✅ |
+| Take screenshot | `bdg dom screenshot out.png` | ✅ |
+| Count links on MDN | `bdg dom eval "document.querySelectorAll('a').length"` → 602 | ✅ |
+| Extract h2 headings | `bdg dom query "h2"` | ✅ |
+| Find form fields | `bdg dom form` | ✅ |
+| Fill text input by index | `bdg dom fill 0 "John Doe"` | ✅ |
+| Select radio by index | `bdg dom click 4` (Medium) | ❌ Hit "Small" |
+| Check a checkbox by index | `bdg dom click 6` (Bacon) | ✅ |
+| Submit form | `bdg dom submit 12` | ✅ POSTed, ❌ "Navigation: no" wrong |
+| Export HAR | `bdg network har x.har` | ✅ |
+| List network errors | `bdg network list --preset errors` | ⚠️ capped at 10 |
+| Find failed requests | `bdg network list --filter status-code:404` | ⚠️ capped at 10 |
+| Inspect POST body | `bdg details network <id>` | ✅ |
+| Monitor console live | `bdg tail` | ✅ |
+| Get main document info | `bdg network document` | ❌ returned favicon |
+| Navigate via JS | `bdg dom eval "location.href = '...'"` | ⚠️ status didn't update |
+| Check page after nav | `bdg status` | ❌ stale URL |
+| Discover CDP methods | `bdg cdp --search cookie` | ✅ |
+| Run raw CDP call | `bdg cdp Runtime.evaluate --params '{}'` | ✅ |
+| Clean up | `bdg stop && bdg cleanup` | ✅ |
+
+---
+
+## Recommended Priorities
+
+1. **Fix radio/checkbox `click-by-index` resolver** — regressed UX for a primary workflow.
+2. **Fix `network list` 10-item cap** — critical for debugging.
+3. **Fix stale `status` after navigation** — breaks verification flows.
+4. **Make `bdg <unknown>` error out instead of treating typos as URLs**.
+5. **Standardize exit codes**: wire Commander `unknown option/missing arg` through the existing `EXIT_CODES.INVALID_ARGUMENTS` (81).
+6. **Fix `network headers` / `network document`** argument validation & target selection.
+7. **Strip stale command suggestions** (`bdg query`, `bdg tabs`, `bdg details dom`).
+8. **Correct the "double colon" header formatting**.
+9. **Honor `--json` / `--quiet` strictly**: no human-readable stderr when JSON requested.

--- a/docs/quality/MANUAL_TESTING_2026-04-16_retest.md
+++ b/docs/quality/MANUAL_TESTING_2026-04-16_retest.md
@@ -1,0 +1,464 @@
+# BDG Manual QA Re-Test Report
+
+**Version:** 0.7.2
+**Date:** 2026-04-16 (retest, after branch `bug-tracking/test-report-2026-04-16`)
+**Scope:** Black-box QA pass against the full CLI surface. No source edits.
+**Tester worked from:** `/opt/homebrew/bin/bdg` → `dist/index.js` (npm-linked)
+
+## Environment
+
+| | |
+|---|---|
+| OS | macOS 15.6.1 (Darwin 24.6.0) |
+| Node | v22.20.0 |
+| Chrome | 147.0.7727.102 (HeadlessChrome reported in UA) |
+| bdg | 0.7.2 |
+| Working dir | `/tmp/bdg-qa-2026-04-16` |
+
+## Methodology
+
+- Discovery via `bdg --help --json`, `bdg cdp --list`, per-command `--help`.
+- Exit codes captured directly (`echo "EXIT: $?"`), never read through a pipe — piped exit codes reflect the trailing process, not bdg.
+- stdout / stderr separated with `2>err >out` for every `--json` command.
+- JSON validated with `python3 -c 'import json,sys; json.load(sys.stdin)'`.
+- Adversarial runs do not trust one result — parallel/flaky cases repeated 3×.
+
+## Commands Exercised
+
+| Command | Flags / sub-commands actually run | Result |
+|---|---|---|
+| `bdg <url>` | bare, `--timeout`, `--headless`, `--no-headless`, `--quiet`, `--debug`, `--chrome-ws-url`, `--max-body-size`, `--verbose` | ✅/❌ mixed |
+| `bdg status` | default, `-v`, `--json`, post-kill | ✅/❌ mixed |
+| `bdg stop` | default, `--kill-chrome`, `--json`, no-session | ✅ |
+| `bdg cleanup` | default, `--force`, `--remove-output`, `--json` | ✅ with caveats |
+| `bdg peek` | default, `--json`, `--verbose`, `--network` (removed), `--console`, `--dom`, `--follow`, `--last 0/-1/5/99999/abc`, `--type Document/XHR/NoSuch` | ✅/❌ mixed |
+| `bdg tail` | default (3s) | ✅ (looks identical to `peek --follow`) |
+| `bdg details` | `network <real-id>`, `network <bogus>`, `console <valid>`, `console 100/abc/-1`, missing args | ❌ exit-code issues |
+| `bdg dom query` | `"*"`, `""`, `"   "`, `"###"`, `"🦄"`, `h1` parallel ×5 ×3 | ❌ parallel race |
+| `bdg dom get` | `<selector>`, `<index>`, `999`, `--raw` | ✅ |
+| `bdg dom eval` | simple, object, number, promise-resolve/reject, throw, syntax error, reference error, infinite loop | ❌ timeout+error-class bugs |
+| `bdg dom a11y` | bare, `tree`, `query role:*`, `query name:*`, bare search `"Pizza"`, `describe 0` | ✅/❌ |
+| `bdg dom form` | default, `--brief`, `--all`, `--json` | ✅ (brief now shows state — fix confirmed) |
+| `bdg dom screenshot` | full, `--selector`, `--index`, `--format jpeg --quality 50`, `--no-full-page`, `--scroll` | ✅ / ❌ exit codes |
+| `bdg dom fill` | selector, index, `999`, `""`/`""`, 10 000-char value | ❌ leaks on empty |
+| `bdg dom click` | selector, index, radio/checkbox-by-index, `-1`, `""`, `999`, `#no-match` | ❌ leaks on empty/`-1` |
+| `bdg dom submit` | form button by index with `--wait-navigation`, missing selector, no cache | ❌ exit codes |
+| `bdg dom pressKey` | `Tab`, `Enter`, `Escape`, `ArrowDown`, `NotAKey`, `--times 3` | ✅ |
+| `bdg dom scroll` | `--bottom`, `--top`, `--down 500`, selector, bare (no arg), `--top --down 500` | ❌ conflicts silently merged |
+| `bdg network list` | default, `--filter status-code:>=400`, `method:POST`, `!method:GET`, `no-such-field:x`, `--preset errors/api/bogus`, `--last 0/5/500`, `--verbose`, `--json` | ❌ JSON shape + `--verbose` no-op |
+| `bdg network har` | no arg, explicit path, `--filter method:POST` | ✅ |
+| `bdg network getCookies` | default, after cookie set, `--url <domain>`, `--json` | ❌ JSON shape |
+| `bdg network headers` | no arg (main doc), `<real-id>`, `<bogus>`, `--header content-type` | ✅ |
+| `bdg network document` | default | ✅ |
+| `bdg console` | default, `--list`, `--level error/warning/info/debug/bogus`, `--last 0/3`, `--json`, `--list --json` | ✅ (summary skipped on info — fix confirmed) |
+| `bdg cdp` | `--list` (all), `<Domain> --list`, `<Method> --describe`, `--search cookie`, execution valid/invalid/lowercase/bad-JSON/missing-params | ✅ |
+| `bdg --help --json` | full tree | ✅ |
+| `bdg --version` | default, `-V`, `--version --json` | ✅/minor |
+
+## Daily-Task Scenarios
+
+| Task | Command used | Worked? |
+|---|---|---|
+| Read page title | `bdg dom eval "document.title"` | ✅ (unquoted string — fix confirmed) |
+| Start on minimal page | `bdg example.com` | ✅ |
+| Start on unreachable host | `bdg http://127.0.0.1:1/` | ❌ reports "Session started" + exit 0 |
+| Start on expired-SSL page | `bdg https://expired.badssl.com/` | ❌ exit 0; no error surface |
+| Start on data: URL | `bdg "data:text/html,<h1>hello</h1>"` | ✅ |
+| Start on file:// | `bdg "file:///etc/hosts"` | ✅ |
+| Discover form fields | `bdg dom form`, `--brief` | ✅ (brief now shows values — fix confirmed) |
+| Fill text, tel, email, time, textarea | `bdg dom fill <idx> "<val>"` | ✅ |
+| Select radio by index | `bdg dom click 4` | ✅ (no longer hits "Small" — fix confirmed) |
+| Check checkbox by index | `bdg dom click 6`, `bdg dom click 9` | ✅ |
+| Submit form | `bdg dom submit 12 --wait-navigation` | ✅ ("Navigation: yes" — fix confirmed) |
+| Verify POST body | `bdg details network <id>` | ✅ |
+| Navigate via JS inside session | `bdg dom eval "location.href='…/Array'"` | ✅; `status` + `pageState` update correctly (fix confirmed) |
+| Inspect heavy SPA network | `bdg network list` on MDN | ✅ (80 requests captured, `--last 500` returns all — fix confirmed) |
+| Filter failing requests | `bdg network list --filter status-code:>=400` | ✅ (human) / ⚠️ JSON uses misleading field names |
+| Export HAR | `bdg network har out.har` | ✅ |
+| HAR with filter | `bdg network har … --filter method:POST` | ✅ |
+| List cookies | `bdg network getCookies` after `/cookies/set?foo=bar` | ✅ (human) / ⚠️ `data: []` shape |
+| Clear cookies | `bdg cdp Network.clearBrowserCookies` | ✅ |
+| Discover CDP methods | `bdg cdp --search cookie`, `bdg cdp Network.getCookies --describe` | ✅ |
+| Call CDP with malformed params | `bdg cdp Runtime.evaluate --params 'not json'` | ✅ (exit 81) |
+| Take full-page screenshot | `bdg dom screenshot out.png` | ✅ |
+| Element-selector screenshot | `bdg dom screenshot --selector form out.png` | ✅ |
+| Capture via cached index | `bdg dom screenshot --index 0 out.png` | ⚠️ "Failed to get element bounds" + exit 0 on some elements |
+| Take JPEG q50 | `bdg dom screenshot --format jpeg --quality 50 out.jpg` | ✅ |
+| Monitor live | `bdg peek --follow` / `bdg tail` | ✅ (appear to be identical) |
+| Parallel DOM queries ×5 | 5× `bdg dom query "h1"` in background | ❌ returns 0-or-1 non-deterministically |
+| Kill daemon mid-session | `kill -9 $(cat ~/.bdg/daemon.pid)` then `bdg status` | ⚠️ recovers, but exit code / double-"Error:" issues |
+| Re-start while running | `bdg example.com` with running session | ✅ (exit 84) |
+
+---
+
+## 🔴 Critical bugs
+
+### C1. `bdg <url> --chrome-ws-url <invalid>` reports success on connection failure
+
+**Repro:**
+```bash
+bdg https://example.com --chrome-ws-url "ws://127.0.0.1:9999/devtools/page/nonexistent" --timeout 5
+echo $?  # 0
+```
+
+**Actual:** stderr dumps raw worker log (`[worker] Starting (PID …)`, internal config JSON, `[worker] WebSocket closed: 1006`) and exits **0**.
+**Expected:** Exit 101 (CDP_CONNECTION_FAILURE) with clean `Error: failed to connect to Chrome at <url>`.
+**Impact:** Automation cannot detect that the session never attached. Silent failure.
+
+### C2. `bdg <url> --max-body-size abc` leaks internal stack trace and exits 0
+
+**Repro:**
+```bash
+bdg example.com --max-body-size abc --timeout 3
+echo $?  # 0
+```
+
+**Actual stderr:**
+```
+file:///Users/szymondzumak/Developer/browser-debugger-cli/dist/commands/shared/validation.js:39
+    throw new CommandError(message, { suggestion }, EXIT_CODES.INVALID_ARGUMENTS);
+          ^
+
+CommandError: Error: Invalid value: "abc" is not a valid integer
+Valid range: 1 to 100
+
+Example: --value 1
+```
+
+**Actual:** Exit **1** (default Node unhandled-exception exit). `CommandError` thrown from `buildSessionOptions` escapes the action handler because `collectorAction(url, options)` in `src/commands/start.ts:226` is called outside the `try { assertValid* } catch` block on lines 216–224. `maxBodySizeRule.validate(...)` (line 153) runs after validation and throws straight to Node.
+**Expected:** Clean error + exit 81; include `--max-body-size` in the validation message instead of `--value`.
+**Impact:** Any invalid numeric option on session start crashes the process with a stack trace that exposes the dist path.
+
+### C3. `bdg dom eval` with `while(true)` wedges the session for 30 s per retry
+
+**Repro:**
+```bash
+bdg example.com
+bdg dom eval "while(true){}"
+echo $?  # 101 after 30 s, message: "Worker response timeout (30s)"
+bdg dom eval "1+1"
+echo $?  # 101 after another 30 s — Runtime is still stuck
+bdg stop # only way to recover
+```
+
+**Actual:** First eval exits 101 (CDP_CONNECTION_FAILURE) with message `Error: Worker response timeout (30s)`. The Runtime target is still executing the loop so every subsequent `dom eval` waits the full 30 s before timing out.
+**Expected:**
+1. Use CDP's own timeout semantics (`Runtime.evaluate` accepts `timeout` in params; or call `Runtime.terminateExecution` on timeout) so the loop is actually killed.
+2. Exit 102 (CDP_TIMEOUT), not 101 — 101 implies the WebSocket died, which it didn't.
+3. Message should name the script, not the worker IPC layer.
+**Impact:** An agent retrying on 101 re-hangs for 30 s each time; the session is effectively bricked until someone notices and calls `bdg stop`.
+
+### C4. `bdg dom click ""`, `click -1`, `fill "" ""` leak internal JS source and break recovery hints
+
+**Repro:**
+```bash
+bdg example.com
+bdg dom click ""
+bdg dom click -1
+bdg dom fill "" ""
+```
+
+**Actual** (all three, exit **110**):
+```
+Error: Script execution failed: Uncaught at line 3, column 31
+
+Expression received: (
+(function(selector, index) {
+  const allMatches = document.querySelectorAll(selector);
+  …
+
+Troubleshooting:
+  1. Verify element exists: bdg dom query ""
+  2. Check element is visible and clickable
+  3. Try direct eval: bdg dom eval "document.querySelector('').click()"
+```
+
+The "Troubleshooting" block recommends `bdg dom query ""` and `bdg dom eval "document.querySelector('')"` — both of which themselves fail. `-1` and `""` need to be rejected at arg-parsing time with exit 81.
+**Impact:** Looks like a bdg bug to users; the stack trace leaks the implementation of the click helper.
+
+### C5. `bdg <unreachable-url>` reports success even when Chrome can't connect
+
+**Repro:**
+```bash
+bdg http://127.0.0.1:1/ --timeout 10
+echo $?  # 0
+bdg status --json | jq .data.pageState
+# { "url": "http://127.0.0.1:1/", "title": "127.0.0.1" }
+
+bdg https://expired.badssl.com/ --timeout 5
+echo $?  # 0
+# title reported: "Privacy error"
+```
+
+**Actual:** Exit 0, "Session started" logged, status reports the original URL and a chrome-error title.
+**Expected:** bdg should surface main-frame navigation failures (`Page.frameStoppedLoading` with `errorText`, or `Page.navigate` returning an errorText on the `Page.frameStartedLoading` → `Page.lifecycleEvent`) and exit 80 (INVALID_URL) or a new code.
+**Impact:** Any monitoring/automation that starts bdg against a broken URL gets a successful exit and happily carries on.
+
+### C6. `bdg network list --json` uses deceptive field names
+
+**Repro:**
+```bash
+bdg https://httpbin.org/forms/post
+# …submit a form so there is a POST…
+bdg network list --filter method:POST --json | jq '.data | {requests: (.requests|length), filtered: (.filtered|length)}'
+# { "requests": 6, "filtered": 1 }
+```
+
+**Actual:** `.data.requests` is the **unfiltered** list; the filtered subset sits at `.data.filtered`. Same holds for `--last N`: `requests` is full, `filtered` is the slice.
+**Expected:** `requests` should be the final (filtered + sliced) result — that's what a consumer expects when they pass `--filter`. Put the full list behind `allRequests` (or drop it) and populate `total` (currently always `null`).
+**Impact:** Any agent that reads `.data.requests` after applying `--filter` gets wrong answers without any signal. Silent JSON-contract violation.
+
+### C7. Parallel `bdg dom query` is racy — returns 0 matches non-deterministically
+
+**Repro:**
+```bash
+bdg https://developer.mozilla.org/en-US/docs/Web/JavaScript
+for round in 1 2 3; do
+  for i in 1 2 3 4 5; do
+    bdg dom query "h1" --json > "r${round}-${i}.json" &
+  done
+  wait
+done
+for f in r*.json; do jq -r '.data.count' "$f"; done
+```
+
+Across 3 rounds × 5 parallel queries, observed `0`s interleaved with `1`s:
+```
+r1: 1 1 0 0 1
+r2: 1 0 1 0 1
+r3: 0 0 1 1 1
+```
+
+Parallel `network list` and `console` were stable in the same rounds. The race is in the DOM query path (cache? document-root attach?).
+**Impact:** Agents fanning out queries can get false negatives and act on them. Bug #23 in the previous report flagged this once; now it reproduces reliably under load.
+
+### C8. `bdg --chrome-ws-url <unreachable>` dumps raw worker stderr
+
+**Repro:**
+```bash
+bdg https://example.com --chrome-ws-url "ws://127.0.0.1:9999/devtools/page/x" --timeout 5
+echo $?  # 106 (WORKER_START_FAILURE) — exit code is correct
+```
+
+**Actual stderr** (exit 106):
+```
+Error: Daemon error: Worker process exited before sending ready signal (code: 1, signal: null)
+stderr: [worker] Starting (PID 16188)
+[worker] Config: {"url":"https://example.com","port":9222,"telemetry":["dom","network","console"],…,"chromeWsUrl":"ws://127.0.0.1:9999/…"}
+[worker] Connecting to existing Chrome instance...
+[worker] WebSocket URL: ws://127.0.0.1:9999/devtools/page/x
+[worker] Using external Chrome (no PID - not managed by bdg)
+[worker] WebSocket closed: 1006 - 
+[worker] Chrome connection lost (code: 1006, reason: )
+```
+
+The exit code is fine; the stderr output is raw worker log spew (internal config, `[worker] …` tags, WebSocket codes). Scriptable consumers have to parse past implementation detail to know "could not reach that WebSocket".
+**Expected:** one-line user-facing error (`Error: could not connect to Chrome at ws://…:9999 (connection refused)`) + `--json` envelope; move the worker log to debug.
+
+---
+
+## 🟡 Significant issues
+
+### S1. `bdg status` writes `Error: Error: Daemon not running` (double prefix)
+
+**Repro:** any state that previously had a daemon but no longer does (e.g. after `kill -9` on the daemon):
+```bash
+bdg example.com; kill -9 $(cat ~/.bdg/daemon.pid)
+bdg status 2>&1 | head -1
+# Error: Error: Daemon not running
+```
+
+The error payload already contains `Error: ` and the formatter prepends another `Error: `. Also visible in JSON:
+```bash
+bdg status --json | jq -r '.error' | head -1
+# Error: Daemon not running
+```
+The `error` field in JSON should be plain `"Daemon not running"`; human output should not double-prefix.
+
+### S2. `bdg details network <bogus-id>` and `details console <n>` exit 104 (UNHANDLED_EXCEPTION)
+
+```bash
+bdg details network BOGUS123;  echo $?  # 104
+bdg details console 999;       echo $?  # 104
+bdg details console abc;       echo $?  # 104
+```
+The semantic code is 83 (RESOURCE_NOT_FOUND). 104 means "bdg crashed", which misleads operators.
+Additional glitch: when no console messages exist, the range string is `"available: 0--1"` — should be `"no console messages captured"`.
+
+### S3. `dom eval` user-script errors exit 110 (SOFTWARE_ERROR)
+
+```bash
+bdg dom eval "throw new Error('x')";   echo $?  # 110
+bdg dom eval "Promise.reject('x')";    echo $?  # 110
+bdg dom eval "return 1";               echo $?  # 110 (syntax error)
+bdg dom eval "noSuch.x";               echo $?  # 110
+```
+`110` is defined as "Generic software error (use specific codes when possible)". A user-provided script throwing is not a bdg software error — it's the user's own code running. Map to 81 (INVALID_ARGUMENTS) or add an `EVAL_RUNTIME_ERROR` code so operators can distinguish "bdg crashed" from "my script threw".
+
+### S4. `dom eval` error hint recommends a nonexistent `--file` option
+
+```
+Tips:
+  - Use single quotes around script: bdg dom eval '...'
+  - For complex scripts, use heredoc or --file option
+```
+`bdg dom eval --file script.js` → `error: unknown option '--file'`. Either add the option or remove the tip.
+
+### S5. `bdg peek --last` range error message is inaccurate
+
+```bash
+bdg peek --last 0      # "Error: Invalid value: \"0\" is not a valid integer"  exit 81
+bdg peek --last 99999  # same message                                           exit 81
+bdg peek --last abc    # same message                                           exit 81
+```
+`0` and `99999` ARE integers. The message should be "out of range (1–1000)". The example `Example: --value 1` also uses a nonexistent flag name — should be `--last`.
+
+### S6. `dom get`, `screenshot --index` suggestion shows negative upper bound when empty
+
+```bash
+bdg dom get 999
+# Error: Index 999 out of range (found 0 nodes)
+# Use an index between 0 and -1   ← negative upper bound is gibberish
+```
+When the range is empty, say "no cached results — run `bdg dom query <selector>` first" rather than "0 and −1".
+
+### S7. `network list --verbose` is a no-op
+
+```bash
+diff <(bdg network list) <(bdg network list --verbose)
+# empty
+```
+Help text promises "Show full URLs and additional details". Either implement or remove.
+
+### S8. `network getCookies --json` shape is inconsistent with the rest of the API
+
+```json
+{ "version": "0.7.2", "success": true, "data": [ {…cookie…}, {…} ] }
+```
+Every other `--json` command uses `data: {…}` with named fields. Cookies should live at `data.cookies: [...]`. Scripts parsing `.data.cookies` get `undefined`.
+
+### S9. `bdg cleanup` spawns a daemon to do cleanup
+
+```bash
+rm -rf ~/.bdg/*
+bdg cleanup
+# [bdg] Starting daemon...
+# [bdg] Daemon started successfully
+# No session files found. Session directory is already clean
+```
+This regresses the spirit of the previous fix for `status` / `stop` (issue #14). Cleanup should not spawn a daemon just to report there's nothing to do.
+
+### S10. `dom submit` without cache / without match exits 0
+
+```bash
+bdg example.com
+bdg dom submit 0      # "No cached query results found"   exit 0
+bdg dom submit "#no"  # "Element not found"               exit 0
+```
+Should exit 87 and 83 respectively (consistent with `dom click`, which does).
+
+### S11. `screenshot --index 0` fails with "Failed to get element bounds" + exit 0
+
+Observed on `form` element after `bdg dom query "form"` — the element is on-screen:
+```bash
+bdg dom query "form"
+bdg dom screenshot --index 0 shot.png
+# Error: Failed to get element bounds
+# Element may not be rendered or visible   exit 0
+```
+Note: `bdg dom screenshot --selector form shot.png` against the same element works. Either the cached nodeId is lost, or the bounds lookup is using the wrong target.
+
+### S12. `dom query` with syntactically invalid CSS silently returns "no matches"
+
+```bash
+bdg dom query "###"   # No nodes found   exit 0
+bdg dom query "🦄"     # No nodes found   exit 0
+```
+Browsers throw `SyntaxError: '###' is not a valid selector`. Treating it as "zero matches" hides user error. Catch the exception at the boundary and exit 81.
+
+---
+
+## 🟠 Minor issues
+
+### M1. CDP help drift
+`bdg cdp --help` says "53 domains"; `bdg cdp --list` returns 54. Pick one.
+
+### M2. `bdg cdp --list` auto-emits JSON without `--json`
+Every other command requires `--json`. Convenient but inconsistent.
+
+### M3. Conflicting flags silently accepted
+- `bdg <url> --headless --no-headless` → last one wins, no warning.
+- `bdg <url> --quiet --debug` → debug wins, `--quiet` discarded.
+- `bdg dom scroll --top --down 500` → `--top` wins silently.
+
+At minimum, warn. Arguably, exit 81.
+
+### M4. `dom scroll --bottom` reports `Position: (0, 0)`
+The "Position" is the input, not the resulting scroll position. Should read the post-scroll `window.scrollY` / `scrollTop`.
+
+### M5. Different JSON shapes for `console` vs `console --list`
+```
+console        --json → data.{success, summary, errors, warnings}
+console --list --json → data.{success, summary, errors, warnings, messages}
+```
+Tolerable but the `messages` field could always be present (empty when not requested) to simplify consumers.
+
+### M6. `stop --json` exposes `chrome: false` when `--kill-chrome` not set
+Reads as a failure. Rename field or add an explanation.
+
+### M7. `--compact` global flag doesn't compact `--json` output of commands
+Help says "compact JSON … for output files" — undocumented that CLI JSON is unaffected.
+
+### M8. `bdg --version --json` returns `0.7.2`, not the `{version, success, data}` envelope
+Trivially inconsistent.
+
+### M9. Chrome user-data-dir persists between sessions in same cwd
+After a form POST, `bdg stop && bdg https://httpbin.org/forms/post` from the same directory reopened to `/post` instead of `/forms/post` for a few seconds. Likely Chrome session restore using the persisted `chrome-profile`. Worth warning users or passing `--disable-session-crashed-bubble` + a clean profile each time.
+
+### M10. `tail` and `peek --follow` appear functionally identical
+`tail --help` describes the tool but the output stream is indistinguishable from `peek --follow`. If they are aliases, document it; if they differ, the difference isn't visible.
+
+### M11. `network list --json`: `total` is always `null`
+Unused field. Drop it or populate it.
+
+### M12. `network headers` / `details network` body formatting
+`network headers <id>` puts the hint line **before** the divider — looks like part of the heading. Minor cosmetic.
+
+### M13. Stale session warning when restarting in directory that had a prior session
+`bdg cleanup` sometimes logs "`[cleanup] Killing cached Chrome process NNN (stale session cleanup)`" even right after a clean `bdg stop`. Suggests the pid-file cleanup races with the stop.
+
+---
+
+## ✅ What works well
+
+- **Radio/checkbox click-by-index is fixed**: `bdg dom click 4` on httpbin's pizza form correctly hits `[value="medium"]`, not `[value="small"]`. Verified through the POST body captured by `bdg details network <id>`.
+- **Form submit navigation detection** now reports `Navigation: yes` when the page navigates, and `bdg status` reflects the new URL within a few seconds.
+- **`--last N`** on `bdg network list` no longer caps at 10 — returned all 80 requests on MDN, JSON envelope in sync with human output.
+- **`dom form --brief`** now shows filled values and checked state (good for quick agent verification).
+- **`a11y`** bare search matches partial names (`bdg dom a11y Pizza` returns six hits including the Group headings).
+- **`dom eval`** on plain string returns unquoted value (`bdg dom eval "document.title"` → `Example Domain`, no wrapping quotes).
+- **`console` summary + `--level`**: filtering to `info` suppresses the error/warning summary; `%c`, `%s`, `%d` substitutions work.
+- **CDP typo suggestions** are excellent: `Runtime.invalidMethod` → "Did you mean: Runtime.evaluate, Runtime.enable".
+- **Unknown top-level command** (`bdg xyzzy`) now exits 80 with actionable hint, rather than launching a Chrome against the typo.
+- **Unknown options** and **missing required args** consistently exit 81 across subcommands (verified on `status --nope`, `details`, `details network`, `dom click`, etc.).
+- **HAR export** preserves all requests and accepts `--filter`.
+- **Extra positional args** after most subcommands correctly exit 81.
+
+---
+
+## Prioritized recommendations
+
+1. **Fix silent-success on unreachable/error pages (C5).** Detect main-frame navigation failure (`Page.frameStoppedLoading` with `errorText`, or `Page.navigate` response's `errorText`) during session start and exit 80. Currently `bdg http://127.0.0.1:1/` and `bdg https://expired.badssl.com/` return 0.
+2. **Catch `CommandError` from `buildSessionOptions` (C2).** The `collectorAction` call in `src/commands/start.ts:226` is outside the validation try/catch; `maxBodySizeRule.validate(...)` escapes as an unhandled Node exception. Wrap `collectorAction` the same way `assertValid*` calls are wrapped. Also fix the "Example: --value 1" template to use the actual flag name.
+3. **Stop the `while(true)` foot-gun (C3).** Pass CDP's own `timeout` to `Runtime.evaluate`, and call `Runtime.terminateExecution` on timeout so subsequent calls recover. Map the timeout to exit 102 (CDP_TIMEOUT) with a script-aware message.
+4. **Reject empty/negative selectors at the boundary (C4).** In the dom-command action handlers, `throw new CommandError(... INVALID_ARGUMENTS)` on `""`, whitespace, or numeric `<0`. Remove the "Troubleshooting" block that self-references the broken call.
+5. **Rename the network-list JSON fields (C6).** `data.requests` should be the final (filter + slice) result. Move the unfiltered list behind `allRequests` or drop it. Populate `total` or remove it. Add a test that `data.requests.length` matches the human "last N of M" header.
+6. **Sanitize `--chrome-ws-url` worker-failure output (C8).** Replace the multi-line worker-log dump with a one-line user-facing error; route the raw worker stderr to debug. Exit code is already correct (106).
+7. **Investigate the parallel `dom query` race (C7).** 3/3 rounds showed non-deterministic 0/1 counts for `h1` on MDN; network / console parallel calls were stable. Likely in the query-cache write path or in `Runtime.callFunctionOn` against a document root that's invalidated mid-flight. Needs a unit-test-level repro before fixing.
+8. **Normalize `status` error prefix (S1).** Strip the `Error: ` prefix inside the error payload *or* don't re-prepend in the formatter — right now both happen.
+9. **Map "not found" errors to semantic codes (S2, S3, S10).** `details network/console <bogus>` → 83 (RESOURCE_NOT_FOUND). `dom eval` user-script throws → 81 (or new `EVAL_RUNTIME_ERROR`). `dom submit` misses → 83/87 (match `dom click`). Reserve 104/110 for actual bdg bugs.
+10. **Clean up validation-message wording (S5, S6, S4).** `peek --last 0` should say "out of range (1–1000)" not "not a valid integer"; remove the "--file option" hint from `dom eval` (doesn't exist); the `--value` placeholder in `positiveIntRule` error messages should use the real flag name.
+11. **Audit flag drift (S7, M1, M2, M7, M10, M11).** `network list --verbose` is a no-op; CDP help says 53 domains but lists 54; `--compact` doesn't affect `--json` CLI output; `tail` and `peek --follow` appear identical; `network list --json` has a perpetually-null `total`. Document or fix — pick one.
+12. **Fix JSON contract drift (S8, M5, M8).** `getCookies --json` should be `data.cookies: [...]`; `console` vs `console --list` JSON shapes should be unified; `--version --json` should emit the standard envelope.
+13. **Drop the daemon spawn from `bdg cleanup` (S9).** Same spirit as the earlier status/stop fix (#14). Inspect `~/.bdg/` directly.
+14. **Treat invalid CSS selectors as errors (S12).** `dom query "###"` should exit 81, not silently "no matches". Catch `DOMException: SyntaxError` at the worker boundary.

--- a/src/commands/cdp.ts
+++ b/src/commands/cdp.ts
@@ -11,7 +11,6 @@ import { runCommand } from '@/commands/shared/CommandRunner.js';
 import type { CdpCommandOptions } from '@/commands/shared/optionTypes.js';
 import { CommandError } from '@/errors/index.js';
 import { callCDP } from '@/ipc/client.js';
-import { validateIPCResponse } from '@/ipc/index.js';
 import { formatHint } from '@/ui/messages/hints.js';
 import { getErrorMessage } from '@/utils/errors.js';
 import { EXIT_CODES } from '@/utils/exitCodes.js';
@@ -473,7 +472,20 @@ async function handleExecuteMethod(
 
   const response = await callCDP(normalized, params);
 
-  validateIPCResponse(response);
+  if (response.status === 'error') {
+    const errMsg = response.error ?? 'CDP call failed';
+    const isInvalidParams = /invalid parameters|must have|is required/i.test(errMsg);
+    return {
+      success: false,
+      error: errMsg,
+      exitCode: isInvalidParams ? EXIT_CODES.INVALID_ARGUMENTS : EXIT_CODES.SOFTWARE_ERROR,
+      errorContext: {
+        suggestion: isInvalidParams
+          ? `See required parameters: bdg cdp ${normalized} --describe`
+          : `List methods: bdg cdp ${normalized.split('.')[0]} --list`,
+      },
+    };
+  }
 
   const cdpResult = response.data?.result;
 

--- a/src/commands/dom/a11y.ts
+++ b/src/commands/dom/a11y.ts
@@ -220,7 +220,7 @@ export function registerA11yCommands(domCmd: Command): void {
     .enablePositionalOptions()
     .action(async (search: string | undefined, options: A11yDescribeCommandOptions) => {
       if (!search) {
-        a11y.help();
+        await handleA11yTree(options);
         return;
       }
 
@@ -233,7 +233,7 @@ export function registerA11yCommands(domCmd: Command): void {
       } else if (isPatternQuery) {
         await handleA11yQuery(search, options);
       } else {
-        await handleA11yQuery(`name:*${search}*`, options);
+        await handleA11yQuery(`name:${search}`, options);
       }
     });
 

--- a/src/commands/dom/formInteraction.ts
+++ b/src/commands/dom/formInteraction.ts
@@ -27,6 +27,7 @@ import type { SubmitResult } from '@/runtime/dom/formSubmitHelpers.js';
 import type { FillResult, ClickResult } from '@/runtime/dom/reactEventHelpers.js';
 import { OutputFormatter } from '@/ui/formatting.js';
 import { EXIT_CODES } from '@/utils/exitCodes.js';
+import { isQuietMode } from '@/utils/outputMode.js';
 
 /**
  * Register form interaction commands.
@@ -339,13 +340,15 @@ function formatSubmitOutput(result: SubmitResult): string {
   if (result.waitTimeMs !== undefined) details.push(['Wait Time', `${result.waitTimeMs}ms`]);
 
   fmt.keyValueList(details, 20);
-  fmt.blank();
-  fmt.text('Next steps:');
-  fmt.section('', [
-    'bdg peek --network --last 10    Check network requests',
-    'bdg console --last 5             Check console messages',
-    'bdg status                       Check session state',
-  ]);
+  if (!isQuietMode()) {
+    fmt.blank();
+    fmt.text('Next steps:');
+    fmt.section('', [
+      'bdg network list --last 10   Check network requests',
+      'bdg console --last 5          Check console messages',
+      'bdg status                    Check session state',
+    ]);
+  }
   return fmt.build();
 }
 

--- a/src/commands/dom/get.ts
+++ b/src/commands/dom/get.ts
@@ -54,7 +54,7 @@ async function handleIndexGetSemantic(index: number, options: DomGetCommandOptio
       const node = resolveNodeWithFallback(a11yNode, domContext, targetNode.nodeId);
 
       if (!node) {
-        const err = elementAtIndexNotFoundError(index, 'cached query');
+        const err = elementAtIndexNotFoundError(index);
         throw new CommandError(
           err.message,
           { suggestion: err.suggestion },

--- a/src/commands/dom/get.ts
+++ b/src/commands/dom/get.ts
@@ -55,11 +55,7 @@ async function handleIndexGetSemantic(index: number, options: DomGetCommandOptio
 
       if (!node) {
         const err = elementAtIndexNotFoundError(index);
-        throw new CommandError(
-          err.message,
-          { suggestion: err.suggestion },
-          EXIT_CODES.RESOURCE_NOT_FOUND
-        );
+        throw new CommandError(err.message, { suggestion: err.suggestion }, EXIT_CODES.STALE_CACHE);
       }
 
       return { success: true, data: { node, domContext } };

--- a/src/commands/dom/query.ts
+++ b/src/commands/dom/query.ts
@@ -4,9 +4,12 @@
 
 import { queryDOMElements } from '@/commands/dom/helpers/index.js';
 import { runCommand } from '@/commands/shared/CommandRunner.js';
+import { handleValidationError } from '@/commands/shared/handleValidationError.js';
 import type { DomQueryCommandOptions } from '@/commands/shared/optionTypes.js';
+import { CommandError } from '@/errors/index.js';
 import { QueryCacheManager } from '@/session/QueryCacheManager.js';
 import { formatDomQuery } from '@/ui/formatters/dom.js';
+import { EXIT_CODES } from '@/utils/exitCodes.js';
 
 /**
  * Handle `bdg dom query <selector>`.
@@ -18,6 +21,17 @@ export async function handleDomQuery(
   selector: string,
   options: DomQueryCommandOptions
 ): Promise<void> {
+  if (selector.trim().length === 0) {
+    handleValidationError(
+      new CommandError(
+        'Selector cannot be empty',
+        { suggestion: 'Pass a CSS selector, e.g., bdg dom query "button"' },
+        EXIT_CODES.INVALID_ARGUMENTS
+      ),
+      options.json ?? false
+    );
+  }
+
   await runCommand(
     async () => {
       const result = await queryDOMElements(selector);

--- a/src/commands/network/list.ts
+++ b/src/commands/network/list.ts
@@ -168,6 +168,7 @@ function formatPresetHelp(): string {
 interface NetworkListResult {
   requests: NetworkRequest[];
   filtered: NetworkRequest[];
+  filteredTotal: number;
   totalCount: number;
 }
 
@@ -219,25 +220,29 @@ export function registerListCommand(networkCmd: Command): void {
 
           if (!result.success) {
             if (result.exitCode === EXIT_CODES.SUCCESS) {
-              return { success: true, data: { requests: [], filtered: [], totalCount: 0 } };
+              return {
+                success: true,
+                data: { requests: [], filtered: [], filteredTotal: 0, totalCount: 0 },
+              };
             }
             return createErrorResult(result.error, result.exitCode);
           }
 
           const filtered = filterRequests(result.data, options, resourceTypes);
+          const displayed = lastN === 0 ? filtered : filtered.slice(-lastN);
           return {
             success: true,
-            data: { requests: result.data, filtered, totalCount: result.data.length },
+            data: {
+              requests: result.data,
+              filtered: displayed,
+              filteredTotal: filtered.length,
+              totalCount: result.data.length,
+            },
           };
         },
         options,
-        (data: NetworkListResult) => {
-          const displayRequests = lastN === 0 ? data.filtered : data.filtered.slice(-lastN);
-          return formatNetworkList(
-            displayRequests,
-            buildFormatOptions(options, data.totalCount, lastN)
-          );
-        }
+        (data: NetworkListResult) =>
+          formatNetworkList(data.filtered, buildFormatOptions(options, data.totalCount, lastN))
       );
     });
 }

--- a/src/commands/network/shared.ts
+++ b/src/commands/network/shared.ts
@@ -155,6 +155,14 @@ export function registerHeadersCommand(networkCmd: Command): void {
             };
           }
 
+          if (!id && !opts.json) {
+            return {
+              success: true,
+              data: response.data,
+              hint: 'Hint: no request ID given — showing main document. List requests: bdg network list',
+            };
+          }
+
           return {
             success: true,
             data: response.data,

--- a/src/commands/network/shared.ts
+++ b/src/commands/network/shared.ts
@@ -131,7 +131,18 @@ export function registerHeadersCommand(networkCmd: Command): void {
             ...(opts.header && { headerName: opts.header }),
           });
 
-          validateIPCResponse(response);
+          if (response.status === 'error') {
+            return {
+              success: false,
+              error: response.error ?? 'Network request not found',
+              exitCode: EXIT_CODES.RESOURCE_NOT_FOUND,
+              errorContext: {
+                suggestion: id
+                  ? 'List captured requests: bdg network list'
+                  : 'No main document captured. Navigate to a page first.',
+              },
+            };
+          }
 
           if (!response.data) {
             return {
@@ -173,7 +184,16 @@ export function registerDocumentCommand(networkCmd: Command): void {
             ...(opts.header && { headerName: opts.header }),
           });
 
-          validateIPCResponse(response);
+          if (response.status === 'error') {
+            return {
+              success: false,
+              error: response.error ?? 'No main document captured',
+              exitCode: EXIT_CODES.RESOURCE_NOT_FOUND,
+              errorContext: {
+                suggestion: 'No main document captured. Navigate to a page first.',
+              },
+            };
+          }
 
           if (!response.data) {
             return {

--- a/src/commands/peek.ts
+++ b/src/commands/peek.ts
@@ -17,10 +17,12 @@ import { handleValidationError } from '@/commands/shared/handleValidationError.j
 import type { PeekCommandOptions } from '@/commands/shared/optionTypes.js';
 import { positiveIntRule, resourceTypeRule } from '@/commands/shared/validation.js';
 import type { Protocol } from '@/connection/typed-cdp.js';
+import { CommandError } from '@/errors/index.js';
 import { filterByResourceType } from '@/telemetry/filters.js';
 import type { BdgOutput } from '@/types.js';
 import { formatPreview, type PreviewOptions } from '@/ui/formatters/preview.js';
 import { followingPreviewMessage, stoppedFollowingPreviewMessage } from '@/ui/messages/preview.js';
+import { EXIT_CODES } from '@/utils/exitCodes.js';
 
 interface ProcessedPreview {
   output: BdgOutput;
@@ -120,7 +122,7 @@ export function registerPeekCommand(program: Command): void {
     .description('Preview collected data without stopping the session')
     .addOption(jsonOption())
     .option('-v, --verbose', 'Use verbose output with full URLs and formatting', false)
-    .option('-n, --network', 'Show only network requests', false)
+    .option('-n, --network', '[REMOVED] Use "bdg network list" instead', false)
     .option('-c, --console', 'Show only console messages', false)
     .option('-d, --dom', 'Show DOM/A11y tree data', false)
     .option('-f, --follow', 'Watch for updates (like tail -f)', false)
@@ -130,9 +132,17 @@ export function registerPeekCommand(program: Command): void {
       'Filter network requests by resource type (comma-separated: Document,XHR,Fetch,etc.)'
     )
     .action(async (options: PeekCommandOptions) => {
-      if (options.network && !options.json) {
-        console.error(
-          'Note: "bdg peek --network" is deprecated. Use "bdg network list" for enhanced filtering.'
+      if (options.network) {
+        handleValidationError(
+          new CommandError(
+            '`bdg peek --network` has been removed.',
+            {
+              suggestion:
+                'Use `bdg network list` for enhanced filtering, presets, and full results.',
+            },
+            EXIT_CODES.INVALID_ARGUMENTS
+          ),
+          options.json ?? false
         );
       }
 

--- a/src/commands/shared/dataFetcher.ts
+++ b/src/commands/shared/dataFetcher.ts
@@ -71,9 +71,13 @@ export async function fetchPreviewData(lastN?: number): Promise<FetchResult<Prev
 
 /**
  * Fetch network requests from daemon.
+ *
+ * Passes `lastN=0` (unlimited) so callers receive the full list and can
+ * apply their own `--last` slicing. The daemon's peek handler otherwise
+ * defaults to 10, silently truncating command output.
  */
 export async function fetchNetworkRequests(): Promise<FetchResult<NetworkRequest[]>> {
-  const result = await fetchPreviewData();
+  const result = await fetchPreviewData(0);
   if (!result.success) return result;
   return { success: true, data: result.data.network };
 }

--- a/src/commands/shared/optionTypes.ts
+++ b/src/commands/shared/optionTypes.ts
@@ -281,6 +281,8 @@ export interface SessionStartOptions {
   chromeWsUrl: string | undefined;
   /** Quiet mode - minimal output for AI agents */
   quiet: boolean;
+  /** Verbose mode - force the post-start landing page even when stdout isn't a TTY */
+  verbose: boolean;
   /** Custom Chrome flags (e.g., ['--ignore-certificate-errors']) */
   chromeFlags: string[] | undefined;
 }

--- a/src/commands/shared/startHelpers.ts
+++ b/src/commands/shared/startHelpers.ts
@@ -7,6 +7,21 @@
 
 import { landingPage } from '@/commands/shared/landingPage.js';
 import type { SessionStartOptions } from '@/commands/shared/optionTypes.js';
+
+/**
+ * Decide whether the post-start landing page should print.
+ *
+ * Humans sitting at an interactive terminal benefit from the one-time
+ * walkthrough of next-step commands, but scripts and CI logs end up with
+ * 50+ lines of decorative text that drowns the actual session output.
+ * Use stdout's TTY status as the signal, with explicit --verbose /
+ * --quiet overrides for users who want to force either outcome.
+ */
+function shouldShowLandingPage(options: SessionStartOptions): boolean {
+  if (options.quiet) return false;
+  if (options.verbose) return true;
+  return process.stdout.isTTY === true;
+}
 import {
   LAUNCHED_CHROME_DESCRIPTION,
   sessionAlreadyRunningError,
@@ -86,13 +101,13 @@ export async function startSessionViaDaemon(
       process.exit(EXIT_CODES.SOFTWARE_ERROR);
     }
 
-    if (options.quiet) {
-      console.error(`Session started: ${data.targetUrl}`);
-    } else {
+    if (shouldShowLandingPage(options)) {
       const landing = landingPage({
         url: data.targetUrl,
       });
       console.error(landing);
+    } else if (!options.quiet) {
+      console.error(`Session started: ${data.targetUrl}`);
     }
 
     process.exit(0);

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -35,6 +35,8 @@ interface CollectorOptions {
   chromeWsUrl?: string;
   /** Quiet mode - suppress verbose landing page output for AI agents. */
   quiet?: boolean;
+  /** Verbose mode - force the post-start landing page even when stdout isn't a TTY. */
+  verbose?: boolean;
   /** Custom Chrome flags (space-separated string). */
   chromeFlags?: string;
 }
@@ -119,6 +121,7 @@ function applyCollectorOptions(command: Command): Command {
       'Connect to existing Chrome via WebSocket URL (e.g., ws://localhost:9222/devtools/page/...)'
     )
     .option('-q, --quiet', 'Quiet mode - minimal output for AI agents', false)
+    .option('--verbose', 'Show the post-start landing page even when stdout is not a TTY', false)
     .option(
       '--chrome-flags <flags>',
       'Custom Chrome flags (space-separated, e.g., --chrome-flags="--ignore-certificate-errors --disable-web-security")'
@@ -141,6 +144,7 @@ function buildSessionOptions(options: CollectorOptions): {
   headless: boolean;
   chromeWsUrl: string | undefined;
   quiet: boolean;
+  verbose: boolean;
   chromeFlags: string[] | undefined;
 } {
   const maxBodySizeRule = positiveIntRule({ min: 1, max: 100, required: false });
@@ -174,6 +178,7 @@ function buildSessionOptions(options: CollectorOptions): {
     headless: options.headless ?? !hasDisplay(),
     chromeWsUrl: options.chromeWsUrl,
     quiet: options.quiet ?? false,
+    verbose: options.verbose ?? false,
     chromeFlags,
   };
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -10,6 +10,7 @@ import { CommandError } from '@/errors/index.js';
 import type { TelemetryType } from '@/types';
 import { startCommandHelpMessage } from '@/ui/messages/commands.js';
 import { EXIT_CODES } from '@/utils/exitCodes.js';
+import { findSimilar } from '@/utils/suggestions.js';
 import { validateChromeWsUrl, validateUrl } from '@/utils/url.js';
 
 /**
@@ -208,6 +209,7 @@ export function registerStartCommands(program: Command): void {
     }
 
     try {
+      assertNotCommandTypo(url, program);
       assertValidUrl(url);
       if (options.chromeWsUrl !== undefined) {
         assertValidChromeWsUrl(options.chromeWsUrl);
@@ -218,6 +220,28 @@ export function registerStartCommands(program: Command): void {
 
     await collectorAction(url, options);
   });
+}
+
+/**
+ * Reject when the URL argument looks like a misspelled command name.
+ *
+ * Without this guard, `bdg statsu` (meant `bdg status`) gets interpreted
+ * as the URL `http://statsu` and Commander launches a browser session
+ * there, which is destructive when a daemon isn't already running.
+ *
+ * Exact command-name matches are handled by Commander before this action
+ * runs, so we only see strings that fell through — the typo case.
+ */
+function assertNotCommandTypo(input: string, program: Command): void {
+  const commandNames = program.commands.map((cmd) => cmd.name()).filter((n) => n.length > 0);
+  const suggestions = findSimilar(input, commandNames, { maxDistance: 2, maxSuggestions: 2 });
+  if (suggestions.length === 0) return;
+  const list = suggestions.map((s) => `bdg ${s}`).join(', ');
+  throw new CommandError(
+    `Unknown command: '${input}'`,
+    { suggestion: `Did you mean: ${list}? (Use 'bdg --help' to list commands.)` },
+    EXIT_CODES.INVALID_ARGUMENTS
+  );
 }
 
 function assertValidUrl(url: string): void {

--- a/src/daemon/__tests__/commandRegistry.contract.test.ts
+++ b/src/daemon/__tests__/commandRegistry.contract.test.ts
@@ -533,13 +533,14 @@ void describe('CommandRegistry', () => {
 
   void describe('worker_network_headers', () => {
     void describe('smart default selection', () => {
-      void it('selects most recent HTML request', async () => {
+      void it('selects most recent Document resource', async () => {
         store.networkRequests.push(
           {
             requestId: 'req-1',
             timestamp: 100,
             method: 'GET',
             url: 'http://a.com',
+            resourceType: 'Document',
             mimeType: 'text/html',
             responseHeaders: { 'content-type': 'text/html' },
           },
@@ -548,6 +549,7 @@ void describe('CommandRegistry', () => {
             timestamp: 200,
             method: 'GET',
             url: 'http://b.com/image.png',
+            resourceType: 'Image',
             mimeType: 'image/png',
             responseHeaders: { 'content-type': 'image/png' },
           },
@@ -556,6 +558,7 @@ void describe('CommandRegistry', () => {
             timestamp: 300,
             method: 'GET',
             url: 'http://c.com',
+            resourceType: 'Document',
             mimeType: 'text/html',
             responseHeaders: { 'content-type': 'text/html; charset=utf-8' },
           }
@@ -567,30 +570,36 @@ void describe('CommandRegistry', () => {
         assert.equal(result.url, 'http://c.com');
       });
 
-      void it('falls back to most recent request with headers when no HTML', async () => {
+      void it('rejects when no Document request exists (avoids picking favicon/API by mimeType)', async () => {
         store.networkRequests.push(
           {
-            requestId: 'req-1',
+            requestId: 'req-favicon',
             timestamp: 100,
             method: 'GET',
-            url: 'http://a.com/image.png',
-            mimeType: 'image/png',
-            responseHeaders: {},
+            url: 'http://a.com/favicon.ico',
+            resourceType: 'Other',
+            mimeType: 'text/html',
+            responseHeaders: { 'content-type': 'text/html' },
           },
           {
-            requestId: 'req-2',
+            requestId: 'req-api',
             timestamp: 200,
             method: 'GET',
             url: 'http://b.com/api',
+            resourceType: 'XHR',
             mimeType: 'application/json',
             responseHeaders: { 'content-type': 'application/json' },
           }
         );
 
-        const result = await registry.worker_network_headers(mockCdp, {});
-
-        assert.equal(result.requestId, 'req-2');
-        assert.equal(result.url, 'http://b.com/api');
+        await assert.rejects(
+          async () => {
+            await registry.worker_network_headers(mockCdp, {});
+          },
+          {
+            message: /No main document request captured/,
+          }
+        );
       });
 
       void it('returns request even when headers are undefined', async () => {
@@ -599,6 +608,7 @@ void describe('CommandRegistry', () => {
           timestamp: 100,
           method: 'GET',
           url: 'http://a.com',
+          resourceType: 'Document',
           mimeType: 'text/html',
         });
 
@@ -615,7 +625,7 @@ void describe('CommandRegistry', () => {
             await registry.worker_network_headers(mockCdp, {});
           },
           {
-            message: 'No network requests with headers found',
+            message: /No main document request captured/,
           }
         );
       });
@@ -699,6 +709,7 @@ void describe('CommandRegistry', () => {
           timestamp: 100,
           method: 'GET',
           url: 'http://example.com',
+          resourceType: 'Document',
           mimeType: 'text/html',
           requestHeaders: { 'User-Agent': 'Chrome', Accept: 'text/html' },
           responseHeaders: {
@@ -722,6 +733,7 @@ void describe('CommandRegistry', () => {
           timestamp: 100,
           method: 'GET',
           url: 'http://example.com',
+          resourceType: 'Document',
           mimeType: 'text/html',
           responseHeaders: {
             'Content-Type': 'text/html',
@@ -742,6 +754,7 @@ void describe('CommandRegistry', () => {
           timestamp: 100,
           method: 'GET',
           url: 'http://example.com',
+          resourceType: 'Document',
           mimeType: 'text/html',
           responseHeaders: { 'Content-Type': 'text/html' },
         });
@@ -760,6 +773,7 @@ void describe('CommandRegistry', () => {
           timestamp: 100,
           method: 'POST',
           url: 'http://api.example.com',
+          resourceType: 'Document',
           mimeType: 'application/json',
           requestHeaders: {
             'Content-Type': 'application/json',

--- a/src/daemon/worker/commandRegistry.ts
+++ b/src/daemon/worker/commandRegistry.ts
@@ -194,15 +194,12 @@ function findTargetRequestForHeaders(
   );
   if (byDocument) return byDocument;
 
-  const byHtml = store.networkRequests.findLast((r) => r.mimeType?.includes('html'));
-  if (byHtml) return byHtml;
+  const anyDocument = store.networkRequests.findLast((r) => r.resourceType === 'Document');
+  if (anyDocument) return anyDocument;
 
-  const byHeaders = store.networkRequests.findLast(
-    (r) => r.responseHeaders && Object.keys(r.responseHeaders).length > 0
+  throw new Error(
+    'No main document request captured. Navigate to a page first, or pass a specific request ID.'
   );
-  if (byHeaders) return byHeaders;
-
-  throw new Error('No network requests with headers found');
 }
 
 /**

--- a/src/daemon/worker/plugins.ts
+++ b/src/daemon/worker/plugins.ts
@@ -25,6 +25,66 @@ export interface TelemetryPluginContext {
   logger: Logger;
 }
 
+const TITLE_REFRESH_DELAYS_MS = [100, 500, 1500];
+
+/**
+ * Refresh the stored page title after a main-frame navigation.
+ *
+ * Best-effort: if the CDP call fails or the document is still loading when
+ * we query, silently give up rather than surfacing the error to the user.
+ */
+async function refreshTitle(cdp: CDPConnection, store: TelemetryStore): Promise<void> {
+  try {
+    const response = await cdp.send('Runtime.evaluate', {
+      expression: 'document.title',
+      returnByValue: true,
+    });
+    const result = (response as { result?: { value?: unknown } }).result;
+    const documentTitle = typeof result?.value === 'string' ? result.value.trim() : '';
+    const prev = store.targetInfo;
+    if (!prev) return;
+    const title = documentTitle || deriveTitleFromUrl(prev.url);
+    if (!title || title === prev.title) return;
+    store.setTargetInfo({ ...prev, title });
+  } catch {
+    // Swallow: losing the title refresh is preferable to crashing the worker.
+  }
+}
+
+/**
+ * Fallback title for pages without a `<title>` tag. Mirrors what Chrome puts
+ * in its targets listing (`/json`) so the status output stays consistent
+ * with what the initial navigation produced.
+ */
+function deriveTitleFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const path = parsed.pathname === '/' ? '' : parsed.pathname;
+    return `${parsed.host}${path}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Schedule a few retries of `refreshTitle` at increasing delays so we don't
+ * depend on Page.loadEventFired alone — some in-page navigations that update
+ * the title don't trigger a new load event.
+ */
+function scheduleTitleRefresh(cdp: CDPConnection, store: TelemetryStore): void {
+  const targetAtScheduleTime = store.targetInfo;
+  for (const delayMs of TITLE_REFRESH_DELAYS_MS) {
+    setTimeout(() => {
+      const current = store.targetInfo;
+      // Only refresh if the URL matches what we saw when scheduling; a new
+      // nav has already set up its own retries by then.
+      if (!current || current.url !== targetAtScheduleTime?.url) return;
+      if (current.title) return;
+      void refreshTitle(cdp, store);
+    }, delayMs).unref();
+  }
+}
+
 export function createDefaultTelemetryPlugins(): TelemetryPlugin[] {
   return [
     {
@@ -40,7 +100,16 @@ export function createDefaultTelemetryPlugins(): TelemetryPlugin[] {
       async start({ cdp, store }) {
         const { cleanup, getCurrentNavigationId } = await startNavigationTracking(
           cdp,
-          store.navigationEvents
+          store.navigationEvents,
+          (url) => {
+            const prev = store.targetInfo;
+            if (!prev) return;
+            store.setTargetInfo({ ...prev, url, title: '' });
+            scheduleTitleRefresh(cdp, store);
+          },
+          () => {
+            void refreshTitle(cdp, store);
+          }
         );
         store.setNavigationResolver(getCurrentNavigationId);
         return cleanup;

--- a/src/errors/messages.ts
+++ b/src/errors/messages.ts
@@ -259,11 +259,19 @@ export function indexOutOfRangeError(index: number, max: number): ErrorWithSugge
 
 /**
  * Element at index not found (stale cache).
+ *
+ * @param index - Zero-based index from the cached query
+ * @param selector - Original selector used by the cache, when known. When
+ *   omitted (e.g. callers that don't carry the selector forward), a generic
+ *   suggestion is emitted so the message never renders a literal "cached
+ *   query" placeholder as if it were a real argument.
  */
-export function elementAtIndexNotFoundError(index: number, selector: string): ErrorWithSuggestion {
+export function elementAtIndexNotFoundError(index: number, selector?: string): ErrorWithSuggestion {
   return {
     message: `Element at index ${index} not found`,
-    suggestion: `Re-run "bdg dom query ${selector}" to refresh the cache`,
+    suggestion: selector
+      ? `Re-run "bdg dom query ${selector}" to refresh the cache`
+      : 'Re-run your original query to refresh the cache',
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { commandRegistry } from '@/commands.js';
 import { isDaemonRunning, launchDaemon } from '@/daemon/launcher.js';
 import { createLogger, enableDebugLogging } from '@/ui/logging/index.js';
 import { getErrorMessage } from '@/utils/errors.js';
+import { EXIT_CODES } from '@/utils/exitCodes.js';
 import { VERSION } from '@/utils/version.js';
 
 const DAEMON_WORKER_ENV_VAR = 'BDG_DAEMON';
@@ -163,6 +164,36 @@ function skipsDaemonLaunchWhenAbsent(): boolean {
   return LOCAL_ONLY_WHEN_NO_DAEMON.has(firstArg);
 }
 
+/**
+ * Map Commander's built-in error codes to bdg's semantic exit codes.
+ *
+ * Commander defaults most validation failures (unknown option, missing
+ * required argument, too-many arguments, invalid argument value) to exit
+ * 1, which lumps them in with generic runtime crashes. Normalize the
+ * user-input cases to EXIT_CODES.INVALID_ARGUMENTS so automation can
+ * discriminate between usage errors and real failures.
+ *
+ * Commander's help/version short-circuits still exit 0.
+ */
+function mapCommanderErrorToExitCode(code: string | undefined): number {
+  if (code === 'commander.helpDisplayed' || code === 'commander.version') {
+    return EXIT_CODES.SUCCESS;
+  }
+  if (
+    code === 'commander.unknownOption' ||
+    code === 'commander.unknownCommand' ||
+    code === 'commander.missingArgument' ||
+    code === 'commander.missingMandatoryOptionValue' ||
+    code === 'commander.invalidArgument' ||
+    code === 'commander.excessArguments' ||
+    code === 'commander.optionMissingArgument' ||
+    code === 'commander.help'
+  ) {
+    return EXIT_CODES.INVALID_ARGUMENTS;
+  }
+  return EXIT_CODES.GENERIC_FAILURE;
+}
+
 async function main(): Promise<void> {
   if (process.argv.includes('--debug')) {
     enableDebugLogging();
@@ -173,7 +204,10 @@ async function main(): Promise<void> {
     .description(CLI_DESCRIPTION)
     .version(VERSION)
     .allowExcessArguments(false)
-    .option('--debug', 'Enable debug logging (verbose output)');
+    .option('--debug', 'Enable debug logging (verbose output)')
+    .exitOverride((err) => {
+      process.exit(mapCommanderErrorToExitCode(err.code));
+    });
 
   commandRegistry.forEach((register) => register(program));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,25 @@ function isDocumentationRequest(): boolean {
   );
 }
 
+/**
+ * Commands that should report "no session" locally when no daemon is running.
+ *
+ * `status` and `stop` are session-state queries that already handle the
+ * daemon-not-running case gracefully. Spawning a fresh daemon just to be
+ * told the session doesn't exist is wasteful and slow.
+ */
+const LOCAL_ONLY_WHEN_NO_DAEMON = new Set(['status', 'stop']);
+
+/**
+ * Check if the invocation is a read-only session query that doesn't need
+ * a daemon spawned on its behalf.
+ */
+function skipsDaemonLaunchWhenAbsent(): boolean {
+  const firstArg = process.argv[2];
+  if (!firstArg) return false;
+  return LOCAL_ONLY_WHEN_NO_DAEMON.has(firstArg);
+}
+
 async function main(): Promise<void> {
   if (process.argv.includes('--debug')) {
     enableDebugLogging();
@@ -169,7 +188,9 @@ async function main(): Promise<void> {
   }
 
   if (!isDaemonWorkerProcess() && !isDocumentationRequest()) {
-    await ensureDaemonRunning(isJsonOutputMode());
+    if (!skipsDaemonLaunchWhenAbsent() || isDaemonRunning()) {
+      await ensureDaemonRunning(isJsonOutputMode());
+    }
   }
 
   program.parse();

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,6 +153,7 @@ async function main(): Promise<void> {
     .name(CLI_NAME)
     .description(CLI_DESCRIPTION)
     .version(VERSION)
+    .allowExcessArguments(false)
     .option('--debug', 'Enable debug logging (verbose output)');
 
   commandRegistry.forEach((register) => register(program));

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,17 @@ function isJsonOutputMode(): boolean {
 }
 
 /**
+ * Check if quiet mode is requested.
+ *
+ * Parallels isJsonOutputMode for the early daemon-launch log-silence path —
+ * we can't call Commander's parsed options here because the daemon spawn
+ * happens before parsing.
+ */
+function isQuietOutputMode(): boolean {
+  return process.argv.includes('--quiet') || process.argv.includes('-q');
+}
+
+/**
  * Check if the invocation is a documentation request that should not
  * trigger daemon startup.
  *
@@ -223,7 +234,7 @@ async function main(): Promise<void> {
 
   if (!isDaemonWorkerProcess() && !isDocumentationRequest()) {
     if (!skipsDaemonLaunchWhenAbsent() || isDaemonRunning()) {
-      await ensureDaemonRunning(isJsonOutputMode());
+      await ensureDaemonRunning(isJsonOutputMode() || isQuietOutputMode());
     }
   }
 

--- a/src/runtime/dom/formDiscovery.ts
+++ b/src/runtime/dom/formDiscovery.ts
@@ -27,6 +27,10 @@ export const FORM_DISCOVERY_SCRIPT = `
     }
     if (element.name) {
       const tag = element.tagName.toLowerCase();
+      const type = element.type?.toLowerCase();
+      if ((type === 'radio' || type === 'checkbox') && element.value) {
+        return tag + '[name="' + CSS.escape(element.name) + '"][value="' + CSS.escape(element.value) + '"]';
+      }
       return tag + '[name="' + CSS.escape(element.name) + '"]';
     }
     const tag = element.tagName.toLowerCase();

--- a/src/runtime/dom/formSubmitHelpers.ts
+++ b/src/runtime/dom/formSubmitHelpers.ts
@@ -185,7 +185,11 @@ async function waitForCompletion(
       }
     };
 
-    const onNavigated = (): void => {
+    const onNavigated = (event: unknown): void => {
+      const frame = (event as { frame?: { parentId?: string } })?.frame;
+      // Only count main-frame navigations; subframe navigations during form
+      // submit (ads, iframes, etc.) shouldn't flip navigationOccurred.
+      if (frame?.parentId !== undefined) return;
       navigationOccurred = true;
       checkCompletion();
     };
@@ -194,9 +198,9 @@ async function waitForCompletion(
     cleanupFunctions.push(cdp.on('Network.loadingFinished', onRequestFinished));
     cleanupFunctions.push(cdp.on('Network.loadingFailed', onRequestFinished));
 
-    if (waitNavigation) {
-      cleanupFunctions.push(cdp.on('Page.frameNavigated', onNavigated));
-    }
+    // Always observe navigation so the result reports navigationOccurred
+    // accurately; `waitNavigation` only controls whether we block for it.
+    cleanupFunctions.push(cdp.on('Page.frameNavigated', onNavigated));
 
     cdp.send('Network.enable').catch((error: Error) => {
       cleanup();

--- a/src/telemetry/a11y.ts
+++ b/src/telemetry/a11y.ts
@@ -171,6 +171,19 @@ function extractRole(rawNode: Protocol.Accessibility.AXNode): string {
  * queryA11yTree(tree, { name: 'Email' });
  * ```
  */
+/**
+ * Drop leading/trailing `*` wildcards from a pattern value.
+ *
+ * Matching is already substring-based via `String.includes`, so callers that
+ * wrap their term in asterisks (e.g. the bare-mode shorthand `name:*Foo*`) no
+ * longer produce patterns that only match a literal asterisk. Internal
+ * asterisks are preserved so users who rely on them to match a literal `*`
+ * still get the current behavior.
+ */
+function stripWildcards(value: string): string {
+  return value.replace(/^\*+/, '').replace(/\*+$/, '');
+}
+
 export function queryA11yTree(tree: A11yTree, pattern: A11yQueryPattern): A11yQueryResult {
   const matches: A11yNode[] = [];
 
@@ -259,7 +272,8 @@ export function parseQueryPattern(patternString: string): A11yQueryPattern {
 
     const separator = separatorMatch[0];
     const [key, ...valueParts] = part.split(separator);
-    const value = valueParts.join(separator);
+    const rawValue = valueParts.join(separator);
+    const value = stripWildcards(rawValue);
 
     if (!value) {
       continue;

--- a/src/telemetry/navigation.ts
+++ b/src/telemetry/navigation.ts
@@ -51,7 +51,9 @@ export interface NavigationEvent {
  */
 export async function startNavigationTracking(
   cdp: CDPConnection,
-  navigations: NavigationEvent[]
+  navigations: NavigationEvent[],
+  onMainFrameNavigation?: (url: string) => void,
+  onPageLoaded?: () => void
 ): Promise<{ cleanup: CleanupFunction; getCurrentNavigationId: () => number }> {
   const registry = new CDPHandlerRegistry();
   const typed = new TypedCDPConnection(cdp);
@@ -77,9 +79,26 @@ export async function startNavigationTracking(
       };
 
       navigations.push(navigation);
+      onMainFrameNavigation?.(params.frame.url);
 
       log.debug(`Main frame navigation detected [${navigationCounter}]: ${params.frame.url}`);
     }
+  });
+
+  registry.registerTyped(typed, 'Page.navigatedWithinDocument', (params) => {
+    navigationCounter++;
+    const navigation: NavigationEvent = {
+      url: params.url,
+      timestamp: Date.now(),
+      navigationId: navigationCounter,
+    };
+    navigations.push(navigation);
+    onMainFrameNavigation?.(params.url);
+    log.debug(`In-document navigation detected [${navigationCounter}]: ${params.url}`);
+  });
+
+  registry.registerTyped(typed, 'Page.loadEventFired', () => {
+    onPageLoaded?.();
   });
 
   // Track DOM.documentUpdated for SPA re-renders and document replacements

--- a/src/telemetry/remoteObject.ts
+++ b/src/telemetry/remoteObject.ts
@@ -215,12 +215,104 @@ export function formatRemoteObject(arg: RemoteObject): string {
 /**
  * Format multiple RemoteObjects as console message text.
  *
- * Joins formatted arguments with spaces, similar to how console.log
- * displays multiple arguments.
+ * When the first argument is a format string, substitution specifiers
+ * (`%s`, `%d`/`%i`, `%f`, `%o`/`%O`, `%c`, `%%`) consume subsequent args
+ * per the WHATWG console spec — `%c` silently drops its CSS argument so
+ * styling metadata doesn't leak into the rendered text.
  *
  * @param args - Array of CDP RemoteObjects
  * @returns Joined formatted string
  */
 export function formatConsoleArgs(args: RemoteObject[]): string {
+  if (args.length === 0) return '';
+  const [first, ...rest] = args;
+  if (
+    first?.type === 'string' &&
+    typeof first.value === 'string' &&
+    /%[csdifoO%]/.test(first.value)
+  ) {
+    const { text, consumed } = applyFormatString(first.value, rest);
+    const leftover = rest.slice(consumed);
+    if (leftover.length === 0) return text;
+    return `${text} ${leftover.map(formatRemoteObject).join(' ')}`;
+  }
   return args.map(formatRemoteObject).join(' ');
+}
+
+/**
+ * Apply console format-string substitution.
+ *
+ * Implements the WHATWG console spec's formatter subset that covers the
+ * cases we've actually seen in the wild. Unknown directives pass through
+ * as literal text so agents still see the raw source.
+ */
+function applyFormatString(
+  format: string,
+  args: RemoteObject[]
+): { text: string; consumed: number } {
+  let out = '';
+  let argIdx = 0;
+  let i = 0;
+  while (i < format.length) {
+    const ch = format[i];
+    const next: string = i + 1 < format.length ? (format[i + 1] ?? '') : '';
+    if (ch !== '%' || next === '') {
+      out += ch ?? '';
+      i += 1;
+      continue;
+    }
+    const arg: RemoteObject | undefined = args[argIdx];
+    switch (next) {
+      case '%':
+        out += '%';
+        break;
+      case 'c':
+        argIdx += 1;
+        break;
+      case 's':
+        if (arg !== undefined) {
+          out +=
+            arg.type === 'string' && typeof arg.value === 'string'
+              ? arg.value
+              : formatRemoteObject(arg);
+          argIdx += 1;
+        } else {
+          out += '%s';
+        }
+        break;
+      case 'd':
+      case 'i':
+        if (arg !== undefined) {
+          const n = Number(arg.value);
+          out += Number.isFinite(n) ? String(Math.trunc(n)) : 'NaN';
+          argIdx += 1;
+        } else {
+          out += `%${next}`;
+        }
+        break;
+      case 'f':
+        if (arg !== undefined) {
+          const n = Number(arg.value);
+          out += Number.isFinite(n) ? String(n) : 'NaN';
+          argIdx += 1;
+        } else {
+          out += '%f';
+        }
+        break;
+      case 'o':
+      case 'O':
+        if (arg !== undefined) {
+          out += formatRemoteObject(arg);
+          argIdx += 1;
+        } else {
+          out += `%${next}`;
+        }
+        break;
+      default:
+        out += `%${next}`;
+        break;
+    }
+    i += 2;
+  }
+  return { text: out, consumed: argIdx };
 }

--- a/src/ui/formatters/console.ts
+++ b/src/ui/formatters/console.ts
@@ -28,13 +28,17 @@ export { formatConsoleSummary } from './console/summarize.js';
 
 /**
  * Format console output based on options. Routes to the per-mode formatter.
+ *
+ * An explicit `--level` filter implies chronological mode — the summary view
+ * is tuned for the default (all-level) input and misreports 'No errors or
+ * warnings found' when the caller has already narrowed to info/debug.
  */
 export function formatConsole(messages: ConsoleMessage[], options: ConsoleFormatOptions): string {
   if (options.json) {
     return formatConsoleJson(messages, options);
   }
 
-  if (options.list) {
+  if (options.list || options.level) {
     return formatConsoleChronological(messages, options);
   }
 

--- a/src/ui/formatters/dom.ts
+++ b/src/ui/formatters/dom.ts
@@ -58,7 +58,7 @@ export function formatDomQuery(data: DomQueryResult): string {
     .section('Next steps:', [
       `Get HTML:        bdg dom get ${exampleIndex}`,
       `Extract text:    bdg cdp Runtime.evaluate --params '{"expression": "document.querySelector('${selector.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}').textContent"}'`,
-      `Full details:    bdg details dom ${exampleIndex}`,
+      `Accessibility:   bdg dom a11y describe ${exampleIndex}`,
     ])
     .build();
 }

--- a/src/ui/formatters/dom.ts
+++ b/src/ui/formatters/dom.ts
@@ -1,5 +1,6 @@
 import type { DomQueryResult, DomGetResult, ScreenshotResult } from '@/types.js';
 import { OutputFormatter } from '@/ui/formatting.js';
+import { isQuietMode } from '@/utils/outputMode.js';
 
 /**
  * Format DOM query results for human-readable output.
@@ -30,17 +31,20 @@ export function formatDomQuery(data: DomQueryResult): string {
   const { count, nodes, selector } = data;
   const fmt = new OutputFormatter();
 
-  if (count === 0) {
-    const safeSelector = selector.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  const quiet = isQuietMode();
 
-    return fmt
-      .text(`No nodes found matching "${selector}"`)
-      .blank()
-      .section('Suggestions:', [
-        `Verify selector: bdg dom eval "document.querySelector('${safeSelector}')"`,
-        'List elements:   bdg dom query "*"',
-      ])
-      .build();
+  if (count === 0) {
+    fmt.text(`No nodes found matching "${selector}"`);
+    if (!quiet) {
+      const safeSelector = selector.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+      fmt
+        .blank()
+        .section('Suggestions:', [
+          `Verify selector: bdg dom eval "document.querySelector('${safeSelector}')"`,
+          'List elements:   bdg dom query "*"',
+        ]);
+    }
+    return fmt.build();
   }
 
   const nodeLines = nodes.map((node) => {
@@ -48,19 +52,21 @@ export function formatDomQuery(data: DomQueryResult): string {
     return `[${node.index}] <${node.tag}${classInfo}> ${node.preview}`;
   });
 
-  const hasMultipleResults = count > 1;
-  const exampleIndex = hasMultipleResults ? (nodes[0]?.index ?? 0) : 0;
+  fmt.text(`Found ${count} node${count === 1 ? '' : 's'} matching "${selector}":`).list(nodeLines);
 
-  return fmt
-    .text(`Found ${count} node${count === 1 ? '' : 's'} matching "${selector}":`)
-    .list(nodeLines)
-    .blank()
-    .section('Next steps:', [
-      `Get HTML:        bdg dom get ${exampleIndex}`,
-      `Extract text:    bdg cdp Runtime.evaluate --params '{"expression": "document.querySelector('${selector.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}').textContent"}'`,
-      `Accessibility:   bdg dom a11y describe ${exampleIndex}`,
-    ])
-    .build();
+  if (!quiet) {
+    const hasMultipleResults = count > 1;
+    const exampleIndex = hasMultipleResults ? (nodes[0]?.index ?? 0) : 0;
+    fmt
+      .blank()
+      .section('Next steps:', [
+        `Get HTML:        bdg dom get ${exampleIndex}`,
+        `Extract text:    bdg cdp Runtime.evaluate --params '{"expression": "document.querySelector('${selector.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}').textContent"}'`,
+        `Accessibility:   bdg dom a11y describe ${exampleIndex}`,
+      ]);
+  }
+
+  return fmt.build();
 }
 
 /**

--- a/src/ui/formatters/dom.ts
+++ b/src/ui/formatters/dom.ts
@@ -57,11 +57,12 @@ export function formatDomQuery(data: DomQueryResult): string {
   if (!quiet) {
     const hasMultipleResults = count > 1;
     const exampleIndex = hasMultipleResults ? (nodes[0]?.index ?? 0) : 0;
+    const safeSelector = selector.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
     fmt
       .blank()
       .section('Next steps:', [
         `Get HTML:        bdg dom get ${exampleIndex}`,
-        `Extract text:    bdg cdp Runtime.evaluate --params '{"expression": "document.querySelector('${selector.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}').textContent"}'`,
+        `Extract text:    bdg dom eval "document.querySelector('${safeSelector}').textContent"`,
         `Accessibility:   bdg dom a11y describe ${exampleIndex}`,
       ]);
   }

--- a/src/ui/formatters/dom.ts
+++ b/src/ui/formatters/dom.ts
@@ -130,6 +130,9 @@ export function formatDomGet(data: DomGetResult): string {
  * ```
  */
 export function formatDomEval(data: { result: unknown }): string {
+  if (typeof data.result === 'string') {
+    return data.result;
+  }
   return JSON.stringify(data.result, null, 2);
 }
 

--- a/src/ui/formatters/form.ts
+++ b/src/ui/formatters/form.ts
@@ -259,27 +259,43 @@ function formatSingleForm(form: DiscoveredForm, fmt: OutputFormatter, brief = fa
  * @param fmt - Output formatter
  */
 function formatBriefFields(form: DiscoveredForm, fmt: OutputFormatter): void {
-  fmt.text('IDX  TYPE         LABEL                    REQ');
-  fmt.text('─'.repeat(50));
+  fmt.text('IDX  TYPE         LABEL                  VAL              REQ');
+  fmt.text('─'.repeat(65));
 
   for (const field of form.fields) {
     if (field.hidden) continue;
     const idx = `[${field.index}]`.padEnd(4);
     const type = (field.inputType ?? field.type).slice(0, 11).padEnd(12);
-    const label = (field.label ?? field.name ?? '(no label)').slice(0, 23).padEnd(24);
+    const label = (field.label ?? field.name ?? '(no label)').slice(0, 21).padEnd(22);
+    const value = briefValueSummary(field).slice(0, 15).padEnd(16);
     const req = field.required ? '*' : '';
-    fmt.text(`${idx} ${type} ${label} ${req}`);
+    fmt.text(`${idx} ${type} ${label} ${value} ${req}`);
   }
 
   if (form.buttons.length > 0) {
-    fmt.text('─'.repeat(50));
+    fmt.text('─'.repeat(65));
     for (const button of form.buttons) {
       const idx = `[${button.index}]`.padEnd(4);
       const type = 'button'.padEnd(12);
-      const label = (button.label || button.type).slice(0, 23).padEnd(24);
+      const label = (button.label || button.type).slice(0, 21).padEnd(22);
       fmt.text(`${idx} ${type} ${label}`);
     }
   }
+}
+
+/**
+ * Render a compact cell showing the current state of a form field.
+ *
+ * Text inputs show the value (empty-string → "∅"); checkbox/radio fields
+ * show their checked state. Agents using `--brief` rely on this column to
+ * verify that a prior `fill` or `click` actually landed.
+ */
+function briefValueSummary(field: FormField): string {
+  if (field.state === 'checked') return '[x]';
+  if (field.state === 'unchecked') return '[ ]';
+  const raw = field.maskedValue ?? (typeof field.value === 'string' ? field.value : '');
+  if (!raw) return '∅';
+  return `"${raw}"`;
 }
 
 /**

--- a/src/ui/formatters/networkHeaders.ts
+++ b/src/ui/formatters/networkHeaders.ts
@@ -55,6 +55,6 @@ function formatHeaderSection(fmt: OutputFormatter, headers: Record<string, strin
   const maxKeyLength = Math.max(...entries.map(([k]) => k.length));
 
   entries.forEach(([key, value]) => {
-    fmt.keyValue(`  ${key}:`, value, maxKeyLength + 4);
+    fmt.keyValue(`  ${key}`, value, maxKeyLength + 4);
   });
 }

--- a/src/ui/formatters/networkList.ts
+++ b/src/ui/formatters/networkList.ts
@@ -70,6 +70,12 @@ function buildHeader(
     return `NETWORK REQUESTS (showing ${showingCount} of ${totalCount})`;
   }
 
+  if (showingCount === 0) {
+    return totalCount === 0
+      ? 'NETWORK REQUESTS (none captured)'
+      : `NETWORK REQUESTS (no matches; ${totalCount} captured)`;
+  }
+
   const lastLimit = options.last ?? 0;
   if (lastLimit > 0 && totalCount > showingCount) {
     return `NETWORK REQUESTS (last ${showingCount} of ${totalCount})`;

--- a/src/ui/formatters/preview.ts
+++ b/src/ui/formatters/preview.ts
@@ -157,66 +157,61 @@ function formatPreviewCompact(output: BdgOutput, options: PreviewOptions): strin
   fmt.blank();
 
   const lastCount = options.last;
-  const hasNetworkData = output.data.network && output.data.network.length > 0;
-  const hasConsoleData = output.data.console && output.data.console.length > 0;
+  const hasExplicitFilter =
+    Boolean(options.network) || Boolean(options.console) || Boolean(options.dom);
+  const showNetwork = (!hasExplicitFilter || options.network) && Boolean(output.data.network);
+  const showConsole = (!hasExplicitFilter || options.console) && Boolean(output.data.console);
 
-  if (!options.console && output.data.network) {
-    if (!options.console || hasNetworkData) {
-      const requests =
-        lastCount === 0 ? output.data.network : output.data.network.slice(-lastCount);
-      const showingCount = requests.length;
-      const totalCount = output.data.network.length;
-      const limitHint = formatLimitHint(showingCount, totalCount);
-      fmt.text(`NETWORK (${showingCount}/${totalCount})${limitHint}:`);
-      if (requests.length === 0) {
-        if (
-          options.filteredTypes &&
-          options.filteredTypes.length > 0 &&
-          options.unfilteredNetworkCount &&
-          options.unfilteredNetworkCount > 0
-        ) {
-          const typesStr = options.filteredTypes.join(', ');
-          fmt.text(
-            `  No ${typesStr} requests found (filtered from ${options.unfilteredNetworkCount} total requests)`
-          );
-          fmt.text(`  Try: bdg peek --network (to see all types)`);
-        } else {
-          fmt.text(`  ${PREVIEW_EMPTY_STATES.NO_DATA}`);
-        }
+  if (showNetwork && output.data.network) {
+    const requests = lastCount === 0 ? output.data.network : output.data.network.slice(-lastCount);
+    const showingCount = requests.length;
+    const totalCount = output.data.network.length;
+    const limitHint = formatLimitHint(showingCount, totalCount);
+    fmt.text(`NETWORK (${showingCount}/${totalCount})${limitHint}:`);
+    if (requests.length === 0) {
+      if (
+        options.filteredTypes &&
+        options.filteredTypes.length > 0 &&
+        options.unfilteredNetworkCount &&
+        options.unfilteredNetworkCount > 0
+      ) {
+        const typesStr = options.filteredTypes.join(', ');
+        fmt.text(
+          `  No ${typesStr} requests found (filtered from ${options.unfilteredNetworkCount} total requests)`
+        );
+        fmt.text(`  Try: bdg peek --network (to see all types)`);
       } else {
-        const networkLines = requests.map((req) => {
-          const typeAbbr = getResourceTypeAbbr(req.resourceType, req.mimeType);
-          // Show error text for failed requests (SSL errors, connection failures, etc.)
-          const status = req.errorText ? `FAILED (${req.errorText})` : (req.status ?? 'pending');
-          const url = truncateUrl(req.url, 50);
-          return `[${req.requestId}] [${typeAbbr}] ${status} ${req.method} ${url}`;
-        });
-        fmt.list(networkLines, 2);
+        fmt.text(`  ${PREVIEW_EMPTY_STATES.NO_DATA}`);
       }
-      fmt.blank();
+    } else {
+      const networkLines = requests.map((req) => {
+        const typeAbbr = getResourceTypeAbbr(req.resourceType, req.mimeType);
+        const status = req.errorText ? `FAILED (${req.errorText})` : (req.status ?? 'pending');
+        const url = truncateUrl(req.url, 50);
+        return `[${req.requestId}] [${typeAbbr}] ${status} ${req.method} ${url}`;
+      });
+      fmt.list(networkLines, 2);
     }
+    fmt.blank();
   }
 
-  if (!options.network && output.data.console) {
-    if (options.console || !options.network || hasConsoleData) {
-      const messages =
-        lastCount === 0 ? output.data.console : output.data.console.slice(-lastCount);
-      const showingCount = messages.length;
-      const totalCount = output.data.console.length;
-      const limitHint = formatLimitHint(showingCount, totalCount);
-      fmt.text(`CONSOLE (${showingCount}/${totalCount})${limitHint}:`);
-      if (messages.length === 0) {
-        fmt.text(`  ${PREVIEW_EMPTY_STATES.NO_DATA}`);
-      } else {
-        const consoleLines = messages.map((msg) => {
-          const prefix = msg.type.toUpperCase().padEnd(5);
-          const text = truncateText(msg.text, 2);
-          return `${prefix} ${text}`;
-        });
-        fmt.list(consoleLines, 2);
-      }
-      fmt.blank();
+  if (showConsole && output.data.console) {
+    const messages = lastCount === 0 ? output.data.console : output.data.console.slice(-lastCount);
+    const showingCount = messages.length;
+    const totalCount = output.data.console.length;
+    const limitHint = formatLimitHint(showingCount, totalCount);
+    fmt.text(`CONSOLE (${showingCount}/${totalCount})${limitHint}:`);
+    if (messages.length === 0) {
+      fmt.text(`  ${PREVIEW_EMPTY_STATES.NO_DATA}`);
+    } else {
+      const consoleLines = messages.map((msg) => {
+        const prefix = msg.type.toUpperCase().padEnd(5);
+        const text = truncateText(msg.text, 2);
+        return `${prefix} ${text}`;
+      });
+      fmt.list(consoleLines, 2);
     }
+    fmt.blank();
   }
 
   if (options.dom && output.data.dom?.a11yTree) {
@@ -264,80 +259,75 @@ function formatPreviewVerbose(output: BdgOutput, options: PreviewOptions): strin
   fmt.blank();
 
   const lastCount = options.last;
-  const hasNetworkData = output.data.network && output.data.network.length > 0;
-  const hasConsoleData = output.data.console && output.data.console.length > 0;
+  const hasExplicitFilter =
+    Boolean(options.network) || Boolean(options.console) || Boolean(options.dom);
+  const showNetwork = (!hasExplicitFilter || options.network) && Boolean(output.data.network);
+  const showConsole = (!hasExplicitFilter || options.console) && Boolean(output.data.console);
 
-  if (!options.console && output.data.network) {
-    if (!options.console || hasNetworkData) {
-      const requests =
-        lastCount === 0 ? output.data.network : output.data.network.slice(-lastCount);
-      const title =
-        lastCount === 0
-          ? `Network Requests (all ${requests.length})`
-          : `Network Requests (last ${requests.length} of ${output.data.network.length})`;
-      fmt.text(title).separator('━', 50);
-      if (requests.length === 0) {
-        if (
-          options.filteredTypes &&
-          options.filteredTypes.length > 0 &&
-          options.unfilteredNetworkCount &&
-          options.unfilteredNetworkCount > 0
-        ) {
-          const typesStr = options.filteredTypes.join(', ');
-          fmt.text(
-            `No ${typesStr} requests found (filtered from ${options.unfilteredNetworkCount} total requests)`
-          );
-          fmt.text(`Try: bdg peek --network (to see all resource types)`);
-        } else {
-          fmt.text(PREVIEW_EMPTY_STATES.NO_NETWORK_REQUESTS);
-        }
+  if (showNetwork && output.data.network) {
+    const requests = lastCount === 0 ? output.data.network : output.data.network.slice(-lastCount);
+    const title =
+      lastCount === 0
+        ? `Network Requests (all ${requests.length})`
+        : `Network Requests (last ${requests.length} of ${output.data.network.length})`;
+    fmt.text(title).separator('━', 50);
+    if (requests.length === 0) {
+      if (
+        options.filteredTypes &&
+        options.filteredTypes.length > 0 &&
+        options.unfilteredNetworkCount &&
+        options.unfilteredNetworkCount > 0
+      ) {
+        const typesStr = options.filteredTypes.join(', ');
+        fmt.text(
+          `No ${typesStr} requests found (filtered from ${options.unfilteredNetworkCount} total requests)`
+        );
+        fmt.text(`Try: bdg peek --network (to see all resource types)`);
       } else {
-        requests.forEach((req) => {
-          const isFailed =
-            Boolean(req.errorText) || (req.status !== undefined && req.status >= 400);
-          const statusColor = isFailed ? 'ERR' : 'OK';
-          const status = req.errorText ? `FAILED` : (req.status?.toString() ?? 'pending');
-          fmt.text(`${statusColor} ${status} ${req.method} ${req.url}`);
-          if (req.errorText) {
-            fmt.text(`  Error: ${req.errorText}`);
-          }
-          if (req.blockedReason) {
-            fmt.text(`  Blocked: ${req.blockedReason}`);
-          }
-          if (req.resourceType) {
-            fmt.text(`  Resource: ${req.resourceType}`);
-          }
-          if (req.mimeType) {
-            fmt.text(`  MIME: ${req.mimeType}`);
-          }
-          fmt.text(
-            `  ID: ${req.requestId} (use 'bdg details network ${req.requestId}' for full details)`
-          );
-        });
+        fmt.text(PREVIEW_EMPTY_STATES.NO_NETWORK_REQUESTS);
       }
-      fmt.blank();
+    } else {
+      requests.forEach((req) => {
+        const isFailed = Boolean(req.errorText) || (req.status !== undefined && req.status >= 400);
+        const statusColor = isFailed ? 'ERR' : 'OK';
+        const status = req.errorText ? `FAILED` : (req.status?.toString() ?? 'pending');
+        fmt.text(`${statusColor} ${status} ${req.method} ${req.url}`);
+        if (req.errorText) {
+          fmt.text(`  Error: ${req.errorText}`);
+        }
+        if (req.blockedReason) {
+          fmt.text(`  Blocked: ${req.blockedReason}`);
+        }
+        if (req.resourceType) {
+          fmt.text(`  Resource: ${req.resourceType}`);
+        }
+        if (req.mimeType) {
+          fmt.text(`  MIME: ${req.mimeType}`);
+        }
+        fmt.text(
+          `  ID: ${req.requestId} (use 'bdg details network ${req.requestId}' for full details)`
+        );
+      });
     }
+    fmt.blank();
   }
 
-  if (!options.network && output.data.console) {
-    if (options.console || !options.network || hasConsoleData) {
-      const messages =
-        lastCount === 0 ? output.data.console : output.data.console.slice(-lastCount);
-      const title =
-        lastCount === 0
-          ? `Console Messages (all ${messages.length})`
-          : `Console Messages (last ${messages.length} of ${output.data.console.length})`;
-      fmt.text(title).separator('━', 50);
-      if (messages.length === 0) {
-        fmt.text(PREVIEW_EMPTY_STATES.NO_CONSOLE_MESSAGES);
-      } else {
-        messages.forEach((msg) => {
-          const icon = msg.type === 'error' ? 'ERR' : msg.type === 'warning' ? 'WARN' : 'INFO';
-          fmt.text(`${icon} [${msg.type}] ${msg.text}`);
-        });
-      }
-      fmt.blank();
+  if (showConsole && output.data.console) {
+    const messages = lastCount === 0 ? output.data.console : output.data.console.slice(-lastCount);
+    const title =
+      lastCount === 0
+        ? `Console Messages (all ${messages.length})`
+        : `Console Messages (last ${messages.length} of ${output.data.console.length})`;
+    fmt.text(title).separator('━', 50);
+    if (messages.length === 0) {
+      fmt.text(PREVIEW_EMPTY_STATES.NO_CONSOLE_MESSAGES);
+    } else {
+      messages.forEach((msg) => {
+        const icon = msg.type === 'error' ? 'ERR' : msg.type === 'warning' ? 'WARN' : 'INFO';
+        fmt.text(`${icon} [${msg.type}] ${msg.text}`);
+      });
     }
+    fmt.blank();
   }
 
   if (!options.follow) {

--- a/src/ui/formatters/preview.ts
+++ b/src/ui/formatters/preview.ts
@@ -8,6 +8,7 @@ import {
   compactTipsMessage,
   verboseCommandsMessage,
 } from '@/ui/messages/preview.js';
+import { isQuietMode } from '@/utils/outputMode.js';
 
 import { semantic } from './semantic.js';
 
@@ -229,7 +230,7 @@ function formatPreviewCompact(output: BdgOutput, options: PreviewOptions): strin
     fmt.blank();
   }
 
-  if (!options.follow) {
+  if (!options.follow && !isQuietMode()) {
     fmt.text(compactTipsMessage());
   }
 
@@ -330,7 +331,7 @@ function formatPreviewVerbose(output: BdgOutput, options: PreviewOptions): strin
     fmt.blank();
   }
 
-  if (!options.follow) {
+  if (!options.follow && !isQuietMode()) {
     fmt.text(verboseCommandsMessage());
   }
 

--- a/src/ui/formatters/preview.ts
+++ b/src/ui/formatters/preview.ts
@@ -198,7 +198,7 @@ function formatPreviewCompact(output: BdgOutput, options: PreviewOptions): strin
   }
 
   if (!options.network && output.data.console) {
-    if (options.network === undefined || hasConsoleData) {
+    if (options.console || !options.network || hasConsoleData) {
       const messages =
         lastCount === 0 ? output.data.console : output.data.console.slice(-lastCount);
       const showingCount = messages.length;
@@ -320,7 +320,7 @@ function formatPreviewVerbose(output: BdgOutput, options: PreviewOptions): strin
   }
 
   if (!options.network && output.data.console) {
-    if (options.network === undefined || hasConsoleData) {
+    if (options.console || !options.network || hasConsoleData) {
       const messages =
         lastCount === 0 ? output.data.console : output.data.console.slice(-lastCount);
       const title =

--- a/src/ui/formatters/status.ts
+++ b/src/ui/formatters/status.ts
@@ -4,6 +4,7 @@ import type { SessionMetadata } from '@/session/metadata.js';
 import { calculateDuration, formatTimeAgo } from '@/session/statusData.js';
 import { OutputFormatter } from '@/ui/formatting.js';
 import { formatDiagnosticsForStatus } from '@/ui/messages/chrome.js';
+import { isQuietMode } from '@/utils/outputMode.js';
 import { isProcessAlive } from '@/utils/process.js';
 import { VERSION } from '@/utils/version.js';
 
@@ -111,13 +112,15 @@ export function formatSessionStatus(
     diagnosticLines.forEach((line) => fmt.text(line));
   }
 
-  fmt
-    .blank()
-    .section('Commands:', [
-      'Peek data:       bdg peek',
-      'Query browser:   bdg dom eval <script>',
-      'End session:     bdg stop',
-    ]);
+  if (!isQuietMode()) {
+    fmt
+      .blank()
+      .section('Commands:', [
+        'Peek data:       bdg peek',
+        'Query browser:   bdg dom eval <script>',
+        'End session:     bdg stop',
+      ]);
+  }
 
   return fmt.build();
 }
@@ -174,9 +177,9 @@ export function formatStatusAsJson(
 export function formatNoSessionMessage(): string {
   const fmt = new OutputFormatter();
 
-  return fmt
-    .text('No active session found')
-    .blank()
-    .section('Suggestions:', ['Start a new session:     bdg <url>'])
-    .build();
+  fmt.text('No active session found');
+  if (!isQuietMode()) {
+    fmt.blank().section('Suggestions:', ['Start a new session:     bdg <url>']);
+  }
+  return fmt.build();
 }

--- a/src/ui/formatters/status.ts
+++ b/src/ui/formatters/status.ts
@@ -115,7 +115,7 @@ export function formatSessionStatus(
     .blank()
     .section('Commands:', [
       'Peek data:       bdg peek',
-      'Query browser:   bdg query <script>',
+      'Query browser:   bdg dom eval <script>',
       'End session:     bdg stop',
     ]);
 
@@ -177,9 +177,6 @@ export function formatNoSessionMessage(): string {
   return fmt
     .text('No active session found')
     .blank()
-    .section('Suggestions:', [
-      'Start a new session:     bdg <url>',
-      'List Chrome tabs:        bdg tabs',
-    ])
+    .section('Suggestions:', ['Start a new session:     bdg <url>'])
     .build();
 }

--- a/src/utils/outputMode.ts
+++ b/src/utils/outputMode.ts
@@ -1,0 +1,31 @@
+/**
+ * Global output-mode detection helpers.
+ *
+ * These look at `process.argv` directly rather than threading Commander's
+ * parsed options through every formatter. Output verbosity is a concern
+ * every command shares, but only a few care enough to change behavior —
+ * letting them query a single helper avoids widening option types across
+ * the codebase just to pass a boolean.
+ */
+
+const QUIET_FLAGS = new Set(['-q', '--quiet']);
+const JSON_FLAGS = new Set(['--json', '-j']);
+
+/**
+ * Whether the current invocation requested quiet output.
+ *
+ * Quiet mode suppresses decorative output — tips, "Next steps:" blocks,
+ * "Suggestions:" sections, post-success hints. Primary data/results and
+ * errors are still emitted. Agents should prefer `--json`; `--quiet` is
+ * for humans and scripts that want terse text output.
+ */
+export function isQuietMode(): boolean {
+  return process.argv.some((arg) => QUIET_FLAGS.has(arg));
+}
+
+/**
+ * Whether the current invocation requested JSON output.
+ */
+export function isJsonMode(): boolean {
+  return process.argv.some((arg) => JSON_FLAGS.has(arg));
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -91,6 +91,28 @@ export function normalizeUrl(url: string): string {
 }
 
 /**
+ * Heuristic: does this input have the shape of a URL or a bare host token?
+ *
+ * Accepts: explicit scheme (`http://…`, `chrome:…`), anything with `.` (host
+ * like `example.com` or IP `1.2.3.4`), anything with `/` (`localhost/api`),
+ * anything with `:` (port `localhost:3000` or scheme separator), bare
+ * `localhost`. Rejects bare single-word tokens like `unknown` or `foo`.
+ *
+ * Rationale: bdg's URL normaliser prepends `http://` to any unscoped input,
+ * so a typo like `bdg foo` silently launches Chrome at `http://foo/`. Guard
+ * that case here; users with a genuine bare intranet hostname can disambiguate
+ * with an explicit `bdg http://foo` or a port.
+ */
+function looksLikeUrl(input: string): boolean {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(input)) return true;
+  if (input.includes('.')) return true;
+  if (input.includes('/')) return true;
+  if (input.includes(':')) return true;
+  if (/^localhost$/i.test(input)) return true;
+  return false;
+}
+
+/**
  * Validate that a URL is valid and usable for Chrome navigation.
  *
  * @param url - URL string to validate
@@ -121,6 +143,13 @@ export function validateUrl(url: string): ValidationResult {
     return invalid(
       `Invalid URL format: '${url}' (contains spaces)`,
       'URLs cannot contain spaces. If your URL has query parameters, wrap it in quotes: bdg "https://example.com/search?q=test"'
+    );
+  }
+
+  if (!looksLikeUrl(url)) {
+    return invalid(
+      `Not a URL or command: '${url}'`,
+      `If this is a hostname, add a scheme or port: 'bdg http://${url}' or 'bdg ${url}:80'. If this was meant to be a command, run 'bdg --help' to list commands.`
     );
   }
 


### PR DESCRIPTION
Tracking PR for manual testing findings from v0.7.2.
Full report: `docs/quality/MANUAL_TESTING_2026-04-16.md`.

**Status: 26 of 29 addressed in this branch.** Three remaining (#9, #10, #23) couldn't be reproduced on current code and need a concrete repro before they can be attempted. Each fix is its own focused commit (run `git log --oneline main..HEAD` on this branch for the breakdown).

## 🔴 Critical (7/7)
- [x] #1 Form index click hits wrong radio/checkbox in grouped inputs
- [x] #2 `network list` silently capped at 10 regardless of `--last` / `--all`
- [x] #3 `bdg <unknown-command>` silently treats typo as a URL
- [x] #4 `bdg status` shows stale URL/title after in-page navigation
- [x] #5 `bdg network document` returns favicon instead of main HTML document
- [x] #6 `bdg network headers` (no arg) returns random request instead of error
- [x] #7 Form submit reports `Navigation: no` when navigation actually occurred

## 🟡 Significant (13/15)
- [x] #8 Exit-code inconsistencies for Commander errors (unknown option / missing arg / excess args)
- [ ] #9 `--json` doesn't silence human-oriented stderr *(could not reproduce on current code — needs a repro)*
- [ ] #10 `status --json` returns `success:true` while stderr prints `Error:` *(could not reproduce — needs a repro)*
- [x] #11 Help suggests nonexistent commands (`bdg query`, `bdg tabs`, `bdg details dom`)
- [x] #12 `bdg dom a11y` bare prints help instead of dumping tree
- [x] #13 `bdg dom a11y "Example"` fails on partial-name match
- [x] #14 `status`/`stop` spawn a daemon just to report "no session"
- [x] #15 `peek --console` (empty) omits `(none)` marker
- [x] #16 `peek --dom` still includes Network section — filter flags don't filter
- [x] #17 `--quiet` promoted to global; strips decorative sections in status/peek/dom query/dom submit
- [x] #18 `dom form --brief` hides filled values / checked state
- [x] #19 Double colons in `network headers` output
- [x] #20 Console `%c` directives rendered as raw text
- [x] #21 Console `--level info` still prints error/warning summary
- [x] #22 Invalid/empty CSS selectors return exit 0

## 🟠 Minor (6/7)
- [ ] #23 Race in parallel DOM queries *(flaky, needs a repeatable repro)*
- [x] #24 `peek --network` hard-error with migration hint to `bdg network list`
- [x] #25 `dom eval` returns quoted JSON for simple string results
- [x] #26 Session-start landing page auto-suppressed outside a TTY; `--verbose` forces it back
- [x] #27 Stale-cache error message reads "cached query" as literal
- [x] #28 Filter `last 0 of N` phrasing when no matches
- [x] #29 `bdg <url> <subcommand>` silently ignores subcommand

## Output-control story (added by #17 + #24 + #26)
- `--json` → machine-readable
- Default → human-readable with hints/next-steps
- `--quiet` / `-q` → global; strips tips, next-steps, suggestions, commands footers
- `--verbose` → on session start, force landing page when piped
- Session-start landing page auto-suppressed when stdout isn't a TTY