### PR TITLE
feat(dom): detect event listeners for interactions

### DIFF
--- a/src/commands/dom/formInteraction.ts
+++ b/src/commands/dom/formInteraction.ts
@@ -22,6 +22,7 @@ import type {
 import { CommandError } from '@/errors/index.js';
 import { internalError } from '@/errors/messages.js';
 import { domClick, domFill, domPressKey, domScroll, domSubmit } from '@/ipc/client.js';
+import type { DomEventListenerSummary } from '@/ipc/protocol/domTypes.js';
 import { type PressKeyResult, type ScrollResult } from '@/runtime/dom/formFillHelpers/index.js';
 import type { SubmitResult } from '@/runtime/dom/formSubmitHelpers.js';
 import type { FillResult, ClickResult } from '@/runtime/dom/reactEventHelpers.js';
@@ -273,6 +274,63 @@ export function registerFormInteractionCommands(program: Command): void {
     });
 }
 
+const FILL_EVENT_TYPES = ['beforeinput', 'change', 'input'];
+const CLICK_EVENT_TYPES = [
+  'click',
+  'dblclick',
+  'mousedown',
+  'mouseup',
+  'pointerdown',
+  'pointerup',
+  'touchend',
+  'touchstart',
+];
+const SUBMIT_EVENT_TYPES = ['click', 'submit', 'mousedown', 'pointerdown'];
+
+/**
+ * Format inspected event listeners for compact human-readable output.
+ */
+function formatListenerSummary(summary: DomEventListenerSummary | undefined): string {
+  if (!summary) return 'unavailable';
+  if (summary.count === 0) return 'none detected';
+
+  const parts: string[] = [];
+  if (summary.targetTypes.length > 0) parts.push(`target: ${summary.targetTypes.join(', ')}`);
+  if (summary.delegatedTypes.length > 0) {
+    parts.push(`parent: ${summary.delegatedTypes.join(', ')}`);
+  }
+  return parts.join('; ');
+}
+
+/**
+ * Return true when inspected listeners include any expected interaction type.
+ */
+function hasExpectedListener(
+  summary: DomEventListenerSummary | undefined,
+  expectedTypes: string[]
+): boolean {
+  if (!summary) return true;
+  return expectedTypes.some((type) => summary.interactionTypes.includes(type));
+}
+
+/**
+ * Append listener metadata and a non-fatal warning for suspicious interactions.
+ */
+function appendListenerDiagnostics(
+  fmt: OutputFormatter,
+  summary: DomEventListenerSummary | undefined,
+  expectedTypes: string[],
+  warning: string
+): void {
+  fmt.blank();
+  fmt.keyValueList([['Event Listeners', formatListenerSummary(summary)]], 15);
+
+  if (!hasExpectedListener(summary, expectedTypes)) {
+    fmt.blank();
+    fmt.text(warning);
+  }
+}
+
 /**
  * Format fill command output for human-readable display.
  */
@@ -294,6 +352,12 @@ function formatFillOutput(result: FillResult): string {
   }
 
   fmt.keyValueList(details, 15);
+  appendListenerDiagnostics(
+    fmt,
+    result.eventListeners,
+    FILL_EVENT_TYPES,
+    '⚠ Warning: No input/change listener detected on the target or immediate parent'
+  );
   return fmt.build();
 }
 
@@ -312,9 +376,15 @@ function formatClickOutput(result: ClickResult): string {
     ],
     15
   );
+  appendListenerDiagnostics(
+    fmt,
+    result.eventListeners,
+    CLICK_EVENT_TYPES,
+    '⚠ Warning: No click-like listener detected on the target or immediate parent'
+  );
   if (!result.clickable) {
     fmt.blank();
-    fmt.text('⚠ Warning: Element may not have a click handler');
+    fmt.text('⚠ Warning: Element may not be semantically clickable');
   }
   return fmt.build();
 }
@@ -339,6 +409,12 @@ function formatSubmitOutput(result: SubmitResult): string {
   if (result.waitTimeMs !== undefined) details.push(['Wait Time', `${result.waitTimeMs}ms`]);
 
   fmt.keyValueList(details, 20);
+  appendListenerDiagnostics(
+    fmt,
+    result.eventListeners,
+    SUBMIT_EVENT_TYPES,
+    '⚠ Warning: No submit/click listener detected on the target or immediate parent'
+  );
   fmt.blank();
   fmt.text('Next steps:');
   fmt.section('', [

--- a/src/commands/dom/helpers/query.ts
+++ b/src/commands/dom/helpers/query.ts
@@ -14,6 +14,11 @@ import {
   eitherArgumentRequiredError,
 } from '@/errors/messages.js';
 import { callCDP } from '@/ipc/client.js';
+import type { DomEventListenerSummary } from '@/ipc/protocol/domTypes.js';
+import {
+  inspectElementEventListeners,
+  type EventListenerCDPSender,
+} from '@/runtime/dom/eventListeners.js';
 import type { DomQueryResult, DomGetResult, DomGetOptions, DomContext } from '@/types.js';
 import { createLogger } from '@/ui/logging/index.js';
 import { ConcurrencyLimiter } from '@/utils/concurrency.js';
@@ -24,6 +29,13 @@ const log = createLogger('dom');
 
 /** Maximum concurrent CDP calls to avoid overwhelming the connection. */
 const CDP_CONCURRENCY_LIMIT = 10;
+
+const ipcCdpSender: EventListenerCDPSender = {
+  async send(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    const response = await callCDP(method, params);
+    return response.data?.result ?? {};
+  },
+};
 
 /**
  * Enable the DOM domain and fetch the document root nodeId.
@@ -59,7 +71,10 @@ function unpackAttributes(attributes: string[] | undefined): Record<string, stri
 /**
  * Query DOM elements by CSS selector via CDP relay.
  */
-export async function queryDOMElements(selector: string): Promise<DomQueryResult> {
+export async function queryDOMElements(
+  selector: string,
+  options: { interactive?: boolean } = {}
+): Promise<DomQueryResult> {
   const rootNodeId = await getDocumentRootId();
 
   const queryResponse = await callCDP('DOM.querySelectorAll', {
@@ -111,21 +126,31 @@ export async function queryDOMElements(selector: string): Promise<DomQueryResult
           tag?: string;
           classes?: string[];
           preview?: string;
+          eventListeners?: DomEventListenerSummary;
         } = { index, nodeId };
 
         if (tag) node.tag = tag;
         if (classes) node.classes = classes;
         if (preview) node.preview = preview;
+        if (options.interactive) {
+          node.eventListeners = await inspectElementEventListeners(ipcCdpSender, nodeId, {
+            includeParent: true,
+          });
+        }
 
         return node;
       })
     )
   );
 
+  const filteredNodes = options.interactive
+    ? nodes.filter((node) => node.eventListeners?.hasInteractionListeners)
+    : nodes;
+
   return {
     selector,
-    count: nodes.length,
-    nodes,
+    count: filteredNodes.length,
+    nodes: filteredNodes,
   };
 }
 
@@ -278,12 +303,16 @@ export async function getDOMElements(options: DomGetOptions): Promise<DomGetResu
           attributes?: Record<string, unknown>;
           classes?: string[];
           outerHTML?: string;
+          eventListeners?: DomEventListenerSummary;
         } = { nodeId };
 
         if (tag) node.tag = tag;
         if (Object.keys(attributes).length > 0) node.attributes = attributes;
         if (classes) node.classes = classes;
         if (outerHTML) node.outerHTML = outerHTML;
+        node.eventListeners = await inspectElementEventListeners(ipcCdpSender, nodeId, {
+          includeParent: true,
+        });
 
         return node;
       })

--- a/src/commands/dom/index.ts
+++ b/src/commands/dom/index.ts
@@ -43,6 +43,7 @@ export function registerDomCommands(program: Command): void {
     .description('Find elements by CSS selector')
     .argument('<selector>', 'CSS selector (e.g., ".error", "#app", "button")')
     .option('-j, --json', 'Output as JSON')
+    .option('--interactive', 'Only show elements with direct or delegated event listeners')
     .action(async (selector: string, options: DomQueryCommandOptions) => {
       await handleDomQuery(selector, options);
     });

--- a/src/commands/dom/query.ts
+++ b/src/commands/dom/query.ts
@@ -20,7 +20,8 @@ export async function handleDomQuery(
 ): Promise<void> {
   await runCommand(
     async () => {
-      const result = await queryDOMElements(selector);
+      const interactive = (options as { interactive?: boolean }).interactive ?? false;
+      const result = await queryDOMElements(selector, { interactive });
       const cacheManager = QueryCacheManager.getInstance();
       const navigationId = await cacheManager.getCurrentNavigationId();
       const resultWithNavId = {

--- a/src/ipc/protocol/domTypes.ts
+++ b/src/ipc/protocol/domTypes.ts
@@ -9,6 +9,34 @@
 
 import type { FormStep, FieldOption } from '@/types.js';
 
+/** Source where an event listener was attached relative to the inspected element. */
+export type DomEventListenerSource = 'target' | 'parent';
+
+/** Normalized event listener metadata from Chrome DevTools Protocol. */
+export interface DomEventListenerInfo {
+  type: string;
+  source: DomEventListenerSource;
+  useCapture: boolean;
+  passive: boolean;
+  once: boolean;
+  scriptId: string;
+  lineNumber: number;
+  columnNumber: number;
+  handlerDescription?: string;
+  backendNodeId?: number;
+}
+
+/** Summary of listeners that may make a DOM element interactive. */
+export interface DomEventListenerSummary {
+  count: number;
+  types: string[];
+  targetTypes: string[];
+  delegatedTypes: string[];
+  interactionTypes: string[];
+  hasInteractionListeners: boolean;
+  listeners: DomEventListenerInfo[];
+}
+
 /**
  * Result of filling an element.
  */
@@ -21,6 +49,9 @@ export interface FillResult {
   inputType?: string | null;
   checked?: boolean;
   suggestion?: string;
+  eventListeners?: DomEventListenerSummary;
+  matchCount?: number;
+  selectedIndex?: number;
 }
 
 /**
@@ -36,6 +67,7 @@ export interface ClickResult {
   selectedIndex?: number;
   requestedIndex?: number;
   suggestion?: string;
+  eventListeners?: DomEventListenerSummary;
 }
 
 /**
@@ -80,6 +112,7 @@ export interface SubmitResult {
   navigationOccurred?: boolean;
   waitTimeMs?: number;
   suggestion?: string;
+  eventListeners?: DomEventListenerSummary;
 }
 
 /**

--- a/src/runtime/dom/__tests__/eventListeners.unit.test.ts
+++ b/src/runtime/dom/__tests__/eventListeners.unit.test.ts
@@ -1,0 +1,108 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  buildEventListenerSummary,
+  inspectElementEventListeners,
+  isInteractionEventType,
+  type EventListenerCDPSender,
+} from '@/runtime/dom/eventListeners.js';
+
+void describe('event listener inspection', () => {
+  void it('summarizes direct and delegated interaction listeners', () => {
+    const summary = buildEventListenerSummary([
+      {
+        type: 'click',
+        source: 'target',
+        useCapture: false,
+        passive: false,
+        once: false,
+        scriptId: '1',
+        lineNumber: 10,
+        columnNumber: 2,
+      },
+      {
+        type: 'input',
+        source: 'parent',
+        useCapture: true,
+        passive: true,
+        once: false,
+        scriptId: '2',
+        lineNumber: 20,
+        columnNumber: 4,
+      },
+    ]);
+
+    assert.equal(summary.count, 2);
+    assert.deepEqual(summary.types, ['click', 'input']);
+    assert.deepEqual(summary.targetTypes, ['click']);
+    assert.deepEqual(summary.delegatedTypes, ['input']);
+    assert.deepEqual(summary.interactionTypes, ['click', 'input']);
+    assert.equal(summary.hasInteractionListeners, true);
+  });
+
+  void it('does not treat non-interaction listeners as interaction signals', () => {
+    assert.equal(isInteractionEventType('animationend'), false);
+    assert.equal(isInteractionEventType('CLICK'), true);
+  });
+
+  void it('inspects target and immediate parent listeners through CDP', async () => {
+    const sender: EventListenerCDPSender = {
+      send(method, params = {}): Promise<unknown> {
+        if (method === 'DOM.resolveNode') {
+          return Promise.resolve({
+            object: { objectId: params['nodeId'] === 7 ? 'target-object' : 'parent-object' },
+          });
+        }
+
+        if (method === 'DOM.describeNode') {
+          return Promise.resolve({ node: { parentId: 3 } });
+        }
+
+        if (method === 'DOMDebugger.getEventListeners') {
+          const objectId = params['objectId'];
+          return Promise.resolve({
+            listeners:
+              objectId === 'target-object'
+                ? [makeListener('click', 'target-handler')]
+                : [makeListener('submit', 'parent-handler')],
+          });
+        }
+
+        throw new Error(`Unexpected CDP method: ${method}`);
+      },
+    };
+
+    const summary = await inspectElementEventListeners(sender, 7);
+
+    assert.deepEqual(summary.targetTypes, ['click']);
+    assert.deepEqual(summary.delegatedTypes, ['submit']);
+    assert.equal(summary.listeners[0]?.source, 'target');
+    assert.equal(summary.listeners[1]?.source, 'parent');
+  });
+});
+
+function makeListener(
+  type: string,
+  description: string
+): {
+  type: string;
+  useCapture: boolean;
+  passive: boolean;
+  once: boolean;
+  scriptId: string;
+  lineNumber: number;
+  columnNumber: number;
+  handler: { description: string };
+} {
+  return {
+    type,
+    useCapture: false,
+    passive: false,
+    once: false,
+    scriptId: '1',
+    lineNumber: 1,
+    columnNumber: 1,
+    handler: { description },
+  };
+}

--- a/src/runtime/dom/eventListeners.ts
+++ b/src/runtime/dom/eventListeners.ts
@@ -1,0 +1,193 @@
+/**
+ * CDP-backed event listener inspection for DOM interaction commands.
+ */
+
+import type { Protocol } from '@/connection/typed-cdp.js';
+import type {
+  DomEventListenerInfo,
+  DomEventListenerSource,
+  DomEventListenerSummary,
+} from '@/ipc/protocol/domTypes.js';
+import { filterDefined } from '@/utils/objects.js';
+
+const INTERACTION_EVENT_TYPES = new Set([
+  'click',
+  'dblclick',
+  'mousedown',
+  'mouseup',
+  'pointerdown',
+  'pointerup',
+  'submit',
+  'input',
+  'change',
+  'beforeinput',
+  'keydown',
+  'keyup',
+  'focus',
+  'blur',
+]);
+
+/** Minimal CDP sender used by direct and IPC-backed callers. */
+export interface EventListenerCDPSender {
+  send(method: string, params?: Record<string, unknown>): Promise<unknown>;
+}
+
+/** Options for inspecting listeners on one DOM node. */
+export interface EventListenerInspectionOptions {
+  /** Include immediate parent listeners as delegated interaction hints. */
+  includeParent?: boolean;
+}
+
+/**
+ * Return true when a listener type is likely relevant to page interaction.
+ */
+export function isInteractionEventType(type: string): boolean {
+  return INTERACTION_EVENT_TYPES.has(type.toLowerCase());
+}
+
+/**
+ * Resolve one CSS selector match to a CDP node id.
+ */
+export async function resolveElementNodeId(
+  cdp: EventListenerCDPSender,
+  selector: string,
+  index = 0
+): Promise<number | null> {
+  await cdp.send('DOM.enable', {});
+
+  const docResponse = await cdp.send('DOM.getDocument', {});
+  const doc = docResponse as Protocol.DOM.GetDocumentResponse;
+  const rootNodeId = doc.root?.nodeId;
+  if (rootNodeId === undefined) {
+    return null;
+  }
+
+  const queryResponse = await cdp.send('DOM.querySelectorAll', { nodeId: rootNodeId, selector });
+  const query = queryResponse as Protocol.DOM.QuerySelectorAllResponse;
+  return query.nodeIds[index] ?? null;
+}
+
+/**
+ * Inspect direct and delegated event listeners for a selector match.
+ */
+export async function inspectElementEventListenersBySelector(
+  cdp: EventListenerCDPSender,
+  selector: string,
+  index = 0,
+  options: EventListenerInspectionOptions = {}
+): Promise<DomEventListenerSummary | undefined> {
+  const nodeId = await resolveElementNodeId(cdp, selector, index);
+  if (nodeId === null) {
+    return undefined;
+  }
+
+  return await inspectElementEventListeners(cdp, nodeId, options);
+}
+
+/**
+ * Inspect direct and delegated event listeners for a CDP node id.
+ */
+export async function inspectElementEventListeners(
+  cdp: EventListenerCDPSender,
+  nodeId: number,
+  options: EventListenerInspectionOptions = {}
+): Promise<DomEventListenerSummary> {
+  const targetListeners = await getNodeEventListeners(cdp, nodeId, 'target');
+  const parentListeners =
+    options.includeParent === false ? [] : await getParentEventListeners(cdp, nodeId);
+  const listeners = [...targetListeners, ...parentListeners];
+  return buildEventListenerSummary(listeners);
+}
+
+/**
+ * Build an interaction-oriented summary from normalized listener metadata.
+ */
+export function buildEventListenerSummary(
+  listeners: DomEventListenerInfo[]
+): DomEventListenerSummary {
+  const types = uniqueSorted(listeners.map((listener) => listener.type));
+  const targetTypes = uniqueSorted(
+    listeners.filter((listener) => listener.source === 'target').map((listener) => listener.type)
+  );
+  const delegatedTypes = uniqueSorted(
+    listeners.filter((listener) => listener.source === 'parent').map((listener) => listener.type)
+  );
+  const interactionTypes = uniqueSorted(types.filter(isInteractionEventType));
+
+  return {
+    count: listeners.length,
+    types,
+    targetTypes,
+    delegatedTypes,
+    interactionTypes,
+    hasInteractionListeners: interactionTypes.length > 0,
+    listeners,
+  };
+}
+
+async function getParentEventListeners(
+  cdp: EventListenerCDPSender,
+  nodeId: number
+): Promise<DomEventListenerInfo[]> {
+  const parentNodeId = await getParentNodeId(cdp, nodeId);
+  if (parentNodeId === null) {
+    return [];
+  }
+
+  return await getNodeEventListeners(cdp, parentNodeId, 'parent');
+}
+
+async function getParentNodeId(
+  cdp: EventListenerCDPSender,
+  nodeId: number
+): Promise<number | null> {
+  const response = await cdp.send('DOM.describeNode', { nodeId });
+  const result = response as Protocol.DOM.DescribeNodeResponse;
+  return result.node.parentId ?? null;
+}
+
+async function getNodeEventListeners(
+  cdp: EventListenerCDPSender,
+  nodeId: number,
+  source: DomEventListenerSource
+): Promise<DomEventListenerInfo[]> {
+  const objectId = await resolveNodeObjectId(cdp, nodeId);
+  if (objectId === null) {
+    return [];
+  }
+
+  const response = await cdp.send('DOMDebugger.getEventListeners', { objectId });
+  const result = response as Protocol.DOMDebugger.GetEventListenersResponse;
+  return result.listeners.map((listener) => normalizeEventListener(listener, source));
+}
+
+async function resolveNodeObjectId(
+  cdp: EventListenerCDPSender,
+  nodeId: number
+): Promise<string | null> {
+  const response = await cdp.send('DOM.resolveNode', { nodeId });
+  const result = response as Protocol.DOM.ResolveNodeResponse;
+  return result.object.objectId ?? null;
+}
+
+function normalizeEventListener(
+  listener: Protocol.DOMDebugger.EventListener,
+  source: DomEventListenerSource
+): DomEventListenerInfo {
+  return filterDefined({
+    type: listener.type,
+    source,
+    useCapture: listener.useCapture,
+    passive: listener.passive,
+    once: listener.once,
+    scriptId: listener.scriptId,
+    lineNumber: listener.lineNumber,
+    columnNumber: listener.columnNumber,
+    handlerDescription: listener.handler?.description,
+    backendNodeId: listener.backendNodeId,
+  }) as unknown as DomEventListenerInfo;
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.toLowerCase()))].sort();
+}

--- a/src/runtime/dom/formFillHelpers/fill.ts
+++ b/src/runtime/dom/formFillHelpers/fill.ts
@@ -12,6 +12,7 @@ import {
   unexpectedResponseFormatError,
   operationFailedError,
 } from '@/errors/messages.js';
+import { inspectElementEventListenersBySelector } from '@/runtime/dom/eventListeners.js';
 import {
   escapeSelectorForJS,
   escapeValueForJS,
@@ -26,7 +27,11 @@ import {
   type FillResult,
   type ClickResult,
 } from '@/runtime/dom/reactEventHelpers.js';
+import { createLogger } from '@/ui/logging/index.js';
+import { getErrorMessage } from '@/utils/errors.js';
 import { EXIT_CODES } from '@/utils/exitCodes.js';
+
+const log = createLogger('dom');
 
 /**
  * Fill a form element with a value in a React-compatible way.
@@ -72,7 +77,7 @@ export async function fillElement(
     }
 
     if (cdpResponse.result?.value && isFillResult(cdpResponse.result.value)) {
-      return cdpResponse.result.value;
+      return await withEventListeners(cdp, selector, cdpResponse.result.value, options.index);
     }
 
     const err = unexpectedResponseFormatError('FillResult');
@@ -126,7 +131,16 @@ export async function clickElement(
     }
 
     if (cdpResponse.result?.value && isClickResult(cdpResponse.result.value)) {
-      return cdpResponse.result.value;
+      const result = await withEventListeners(
+        cdp,
+        selector,
+        cdpResponse.result.value,
+        options.index
+      );
+      if (result.eventListeners && hasClickLikeListeners(result.eventListeners.interactionTypes)) {
+        return { ...result, clickable: true };
+      }
+      return result;
     }
 
     const err = unexpectedResponseFormatError('ClickResult');
@@ -139,4 +153,45 @@ export async function clickElement(
     const err = operationFailedError('click element', errorMessage);
     throw new CommandError(err.message, { suggestion: err.suggestion }, EXIT_CODES.SOFTWARE_ERROR);
   }
+}
+
+async function withEventListeners<T extends FillResult | ClickResult>(
+  cdp: CDPConnection,
+  selector: string,
+  result: T,
+  fallbackIndex: number | undefined
+): Promise<T> {
+  if (!result.success) {
+    return result;
+  }
+
+  try {
+    const index = result.selectedIndex ?? fallbackIndex ?? 0;
+    const eventListeners = await inspectElementEventListenersBySelector(cdp, selector, index, {
+      includeParent: true,
+    });
+    if (eventListeners === undefined) {
+      return result;
+    }
+
+    return { ...result, eventListeners };
+  } catch (error) {
+    log.debug(`Unable to inspect event listeners for ${selector}: ${getErrorMessage(error)}`);
+    return result;
+  }
+}
+
+function hasClickLikeListeners(types: string[]): boolean {
+  return types.some((type) =>
+    [
+      'click',
+      'dblclick',
+      'mousedown',
+      'mouseup',
+      'pointerdown',
+      'pointerup',
+      'touchstart',
+      'touchend',
+    ].includes(type)
+  );
 }

--- a/src/runtime/dom/formSubmitHelpers.ts
+++ b/src/runtime/dom/formSubmitHelpers.ts
@@ -6,6 +6,9 @@ import type { ClickResult } from './reactEventHelpers.js';
 
 import type { CDPConnection } from '@/connection/cdp.js';
 import { CDPConnectionError, CDPTimeoutError } from '@/connection/errors.js';
+import type { SubmitResult } from '@/ipc/protocol/domTypes.js';
+
+export type { SubmitResult } from '@/ipc/protocol/domTypes.js';
 
 import { clickElement } from './formFillHelpers/index.js';
 
@@ -22,9 +25,6 @@ export interface SubmitOptions {
   /** Maximum time to wait in milliseconds (default: 10000) */
   timeout?: number;
 }
-
-import type { SubmitResult } from '@/ipc/protocol/domTypes.js';
-export type { SubmitResult } from '@/ipc/protocol/domTypes.js';
 
 /**
  * Submit a form by clicking the submit button and waiting for completion.
@@ -74,6 +74,7 @@ export async function submitForm(
       error: clickResult.error ?? 'Click failed',
       selector: clickResult.selector ?? selector,
       clicked: false,
+      ...(clickResult.eventListeners && { eventListeners: clickResult.eventListeners }),
     };
   }
 
@@ -85,6 +86,7 @@ export async function submitForm(
       networkRequests: 0,
       navigationOccurred: false,
       waitTimeMs: Date.now() - startTime,
+      ...(clickResult.eventListeners && { eventListeners: clickResult.eventListeners }),
     };
   }
 
@@ -102,6 +104,7 @@ export async function submitForm(
       networkRequests: waitResult.networkRequests,
       navigationOccurred: waitResult.navigationOccurred,
       waitTimeMs: Date.now() - startTime,
+      ...(clickResult.eventListeners && { eventListeners: clickResult.eventListeners }),
     };
   } catch (error) {
     if (error instanceof CDPTimeoutError) {
@@ -111,6 +114,7 @@ export async function submitForm(
         selector: selector,
         clicked: true,
         waitTimeMs: Date.now() - startTime,
+        ...(clickResult.eventListeners && { eventListeners: clickResult.eventListeners }),
       };
     }
     throw error;

--- a/src/runtime/dom/reactEventHelpers.ts
+++ b/src/runtime/dom/reactEventHelpers.ts
@@ -30,6 +30,7 @@ export const REACT_FILL_SCRIPT = `
   }
   
   let el;
+  let selectedIndex;
   const index = options.index;
   
   // If index is provided, use it directly (0-based)
@@ -45,8 +46,10 @@ export const REACT_FILL_SCRIPT = `
       };
     }
     el = allMatches[index];
+    selectedIndex = index;
   } else {
     el = allMatches[0];
+    selectedIndex = 0;
   }
   
   const tagName = el.tagName.toLowerCase();
@@ -122,7 +125,9 @@ export const REACT_FILL_SCRIPT = `
     value: el.value || el.textContent,
     elementType: tagName,
     inputType: inputType || null,
-    checked: el.checked || undefined
+    checked: el.checked || undefined,
+    matchCount: allMatches.length,
+    selectedIndex: selectedIndex
   };
 })
 `;
@@ -148,6 +153,7 @@ export const CLICK_ELEMENT_SCRIPT = `
   }
   
   let el;
+  let selectedIndex;
   
   // If index is provided, use it directly (0-based)
   if (typeof index === 'number' && index >= 0) {
@@ -162,13 +168,17 @@ export const CLICK_ELEMENT_SCRIPT = `
       };
     }
     el = allMatches[index];
+    selectedIndex = index;
   } else if (allMatches.length === 1) {
     // Single match - use it directly
     el = allMatches[0];
+    selectedIndex = 0;
   } else {
     // Multiple matches without index - find first visible one
     el = allMatches[0];
-    for (const candidate of allMatches) {
+    selectedIndex = 0;
+    for (let candidateIndex = 0; candidateIndex < allMatches.length; candidateIndex++) {
+      const candidate = allMatches[candidateIndex];
       const style = window.getComputedStyle(candidate);
       const rect = candidate.getBoundingClientRect();
       
@@ -181,6 +191,7 @@ export const CLICK_ELEMENT_SCRIPT = `
       
       if (isVisible) {
         el = candidate;
+        selectedIndex = candidateIndex;
         break;
       }
     }
@@ -210,7 +221,7 @@ export const CLICK_ELEMENT_SCRIPT = `
     elementType: tagName,
     clickable: isClickable,
     matchCount: allMatches.length,
-    selectedIndex: typeof index === 'number' ? index : undefined
+    selectedIndex: selectedIndex
   };
 })
 `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { Protocol } from '@/connection/typed-cdp.js';
+import type { DomEventListenerSummary } from '@/ipc/protocol/domTypes.js';
 
 /**
  * Standard response envelope for all bdg command JSON output.
@@ -331,6 +332,7 @@ export interface DomQueryResult {
     tag?: string;
     classes?: string[];
     preview?: string;
+    eventListeners?: DomEventListenerSummary;
   }>;
   /** Navigation ID when query was performed (for staleness detection). */
   navigationId?: number;
@@ -346,6 +348,7 @@ export interface DomGetResult {
     attributes?: Record<string, unknown>;
     classes?: string[];
     outerHTML?: string;
+    eventListeners?: DomEventListenerSummary;
   }>;
 }
 
@@ -411,6 +414,7 @@ export interface DomGetOptions {
   nodeId?: number;
   all?: boolean;
   nth?: number;
+  interactive?: boolean;
 }
 
 /**

--- a/src/ui/formatters/dom.ts
+++ b/src/ui/formatters/dom.ts
@@ -1,5 +1,21 @@
+import type { DomEventListenerSummary } from '@/ipc/protocol/domTypes.js';
 import type { DomQueryResult, DomGetResult, ScreenshotResult } from '@/types.js';
 import { OutputFormatter } from '@/ui/formatting.js';
+
+/**
+ * Format listener metadata for concise human-readable DOM output.
+ */
+function formatListenerSummary(summary: DomEventListenerSummary | undefined): string | null {
+  if (!summary) return null;
+  if (summary.count === 0) return 'Event listeners: none detected';
+
+  const parts: string[] = [];
+  if (summary.targetTypes.length > 0) parts.push(`target: ${summary.targetTypes.join(', ')}`);
+  if (summary.delegatedTypes.length > 0) {
+    parts.push(`parent: ${summary.delegatedTypes.join(', ')}`);
+  }
+  return `Event listeners: ${parts.join('; ')}`;
+}
 
 /**
  * Format DOM query results for human-readable output.
@@ -45,7 +61,9 @@ export function formatDomQuery(data: DomQueryResult): string {
 
   const nodeLines = nodes.map((node) => {
     const classInfo = node.classes?.length ? ` class="${node.classes.join(' ')}"` : '';
-    return `[${node.index}] <${node.tag}${classInfo}> ${node.preview}`;
+    const listenerInfo = formatListenerSummary(node.eventListeners);
+    const listenerSuffix = listenerInfo ? ` — ${listenerInfo}` : '';
+    return `[${node.index}] <${node.tag}${classInfo}> ${node.preview}${listenerSuffix}`;
   });
 
   const hasMultipleResults = count > 1;
@@ -97,12 +115,17 @@ export function formatDomGet(data: DomGetResult): string {
 
   if (nodes.length === 1) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return nodes[0]!.outerHTML ?? '';
+    const node = nodes[0]!;
+    const html = node.outerHTML ?? '';
+    const listenerInfo = formatListenerSummary(node.eventListeners);
+    return listenerInfo ? `${html}\n\n${listenerInfo}` : html;
   }
 
   const fmt = new OutputFormatter();
   nodes.forEach((node, i) => {
+    const listenerInfo = formatListenerSummary(node.eventListeners);
     fmt.text(`[${i + 1}] ${node.outerHTML}`);
+    if (listenerInfo) fmt.text(`    ${listenerInfo}`);
   });
 
   return fmt.build();


### PR DESCRIPTION
## Summary
- add CDP-backed DOM event listener inspection using DOM.resolveNode + DOMDebugger.getEventListeners
- enrich dom click/fill/submit results with direct and immediate-parent delegated listener metadata
- add non-fatal interaction warnings plus listener metadata in dom query/dom get human and JSON output
- add dom query --interactive to filter to elements with interaction listeners without slowing default queries
- add unit coverage for listener summaries and delegated parent inspection

Closes #112

## Validation
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/eslint changed files
- ./node_modules/.bin/tsx --test src/runtime/dom/__tests__/eventListeners.unit.test.ts
- npm run build
- npm run lint (passes with pre-existing warnings in pressKey.ts and scroll.ts)